### PR TITLE
Clean up handling queries, dont initialize gene-normalizer in init

### DIFF
--- a/tests/classifiers/classifier_base.py
+++ b/tests/classifiers/classifier_base.py
@@ -2,6 +2,9 @@
 import yaml
 from variation.tokenizers import Tokenize
 from tests import PROJECT_ROOT
+from variation.tokenizers.caches import AminoAcidCache
+from variation.tokenizers import GeneSymbol
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class ClassifierBase:
@@ -16,7 +19,8 @@ class ClassifierBase:
             {'should_match': [], 'should_not_match': []}
         )
         self.classifier = self.classifier_instance()
-        self.tokenizer = Tokenize()
+        self.tokenizer = Tokenize(AminoAcidCache(),
+                                  GeneSymbol(GeneQueryHandler()))
 
     def classifier_instance(self):
         """Check that the classifier_instance method is implemented."""

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,22 +1,10 @@
 """Module for testing the normalize endpoint."""
 import pytest
-from ga4gh.vrs.dataproxy import SeqRepoDataProxy
-from ga4gh.vrs.extras.translator import Translator
-from variation.normalize import Normalize
+from variation.query import QueryHandler
 from variation.schemas.ga4gh_vrsatile import VariationDescriptor
-from variation.to_vrs import ToVRS
-from variation.main import normalize as normalize_get_response
-from variation.main import translate as to_vrs_get_response
-from variation.classifiers import Classify
-from variation.tokenizers import Tokenize
-from variation.validators import Validate
-from variation.translators import Translate
-from variation.data_sources import SeqRepoAccess, TranscriptMappings, \
-    UTA, MANETranscriptMappings
-from variation.mane_transcript import MANETranscript
-from variation.tokenizers import GeneSymbol
-from variation.tokenizers.caches import AminoAcidCache
 from datetime import datetime
+from variation.main import normalize as normalize_get_response
+from variation.main import to_vrs as to_vrs_get_response
 import copy
 
 
@@ -26,40 +14,13 @@ def test_normalize():
     class TestNormalize:
 
         def __init__(self):
-            tokenizer = Tokenize()
-            classifier = Classify()
-            seqrepo_access = SeqRepoAccess()
-            transcript_mappings = TranscriptMappings()
-            gene_symbol = GeneSymbol()
-            amino_acid_cache = AminoAcidCache()
-            uta = UTA()
-            mane_transcript_mappings = MANETranscriptMappings()
-            dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
-            tlr = Translator(data_proxy=dp)
-            mane_transcript = MANETranscript(seqrepo_access,
-                                             transcript_mappings,
-                                             mane_transcript_mappings, uta)
-            validator = Validate(seqrepo_access, transcript_mappings,
-                                 gene_symbol, mane_transcript, uta,
-                                 dp, tlr, amino_acid_cache)
-            translator = Translate()
+            self.query_handler = QueryHandler()
 
-            self.to_vrs = ToVRS(tokenizer, classifier, seqrepo_access,
-                                transcript_mappings, gene_symbol,
-                                amino_acid_cache, uta,
-                                mane_transcript_mappings, mane_transcript,
-                                validator, translator)
-            self.test_normalize = Normalize(seqrepo_access, uta)
+        def to_vrs(self, q):
+            return self.query_handler.to_vrs(q)
 
         def normalize(self, q):
-            validations, warnings = self.to_vrs.get_validations(
-                q, normalize_endpoint=True
-            )
-            resp = \
-                self.test_normalize.normalize(q,
-                                              validations,
-                                              warnings)
-            return resp
+            return self.query_handler.normalize(q)
 
     return TestNormalize()
 

--- a/tests/tokenizers/test_gene.py
+++ b/tests/tokenizers/test_gene.py
@@ -2,6 +2,7 @@
 import unittest
 from variation.tokenizers import GeneSymbol
 from .tokenizer_base import TokenizerBase
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenePairTokenizer(TokenizerBase, unittest.TestCase):
@@ -9,7 +10,7 @@ class TestGenePairTokenizer(TokenizerBase, unittest.TestCase):
 
     def tokenizer_instance(self):
         """Return the Gene Pair tokenizer instance."""
-        return GeneSymbol()
+        return GeneSymbol(GeneQueryHandler())
 
     def token_type(self):
         """Return the Gene Pair token type."""

--- a/tests/translators/test_amino_acid_deletion.py
+++ b/tests/translators/test_amino_acid_deletion.py
@@ -11,6 +11,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidDeletionTranslator(TranslatorBase, unittest.TestCase):
@@ -28,7 +29,8 @@ class TestAminoAcidDeletionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AAD_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/translators/test_amino_acid_delins.py
+++ b/tests/translators/test_amino_acid_delins.py
@@ -11,6 +11,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidDelInsTranslator(TranslatorBase, unittest.TestCase):
@@ -28,7 +29,8 @@ class TestAminoAcidDelInsTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AAD_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/translators/test_amino_acid_insertion.py
+++ b/tests/translators/test_amino_acid_insertion.py
@@ -11,6 +11,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidInsertionTranslator(TranslatorBase, unittest.TestCase):
@@ -28,7 +29,8 @@ class TestAminoAcidInsertionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AAI_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/translators/test_amino_acid_substitution.py
+++ b/tests/translators/test_amino_acid_substitution.py
@@ -11,6 +11,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidSubstitutionTranslator(TranslatorBase, unittest.TestCase):
@@ -28,7 +29,8 @@ class TestAminoAcidSubstitutionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AASUB_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/translators/test_coding_dna_deletion.py
+++ b/tests/translators/test_coding_dna_deletion.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNADeletionTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestCodingDNADeletionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CDNAD_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_coding_dna_delins.py
+++ b/tests/translators/test_coding_dna_delins.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNADelInsTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestCodingDNADelInsTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CDNADELINS_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_coding_dna_insertion.py
+++ b/tests/translators/test_coding_dna_insertion.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNAInsertionTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestCodingDNAInsertionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CDNAD_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_coding_dna_silent_mutation.py
+++ b/tests/translators/test_coding_dna_silent_mutation.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNASilentMutationTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestCodingDNASilentMutationTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CDNASM_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_coding_dna_substitution.py
+++ b/tests/translators/test_coding_dna_substitution.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNASubstitutionTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestCodingDNASubstitutionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CDNASUB_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_genomic_deletion.py
+++ b/tests/translators/test_genomic_deletion.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicDeletionTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestGenomicDeletionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GD_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_genomic_delins.py
+++ b/tests/translators/test_genomic_delins.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicDelInsTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestGenomicDelInsTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GENOMICDELINS_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_genomic_insertion.py
+++ b/tests/translators/test_genomic_insertion.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicInsertionTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestGenomicInsertionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GD_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_genomic_silent_mutation.py
+++ b/tests/translators/test_genomic_silent_mutation.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicSilentMutationTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestGenomicSilentMutationTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GENOMICSM_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_genomic_substitution.py
+++ b/tests/translators/test_genomic_substitution.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicSubstitutionTranslator(TranslatorBase, unittest.TestCase):
@@ -27,7 +28,8 @@ class TestGenomicSubstitutionTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GSUB_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/translators/test_polypeptide_truncation.py
+++ b/tests/translators/test_polypeptide_truncation.py
@@ -11,6 +11,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestPolypeptideTruncationTranslator(TranslatorBase, unittest.TestCase):
@@ -28,7 +29,8 @@ class TestPolypeptideTruncationTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return PT_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/translators/test_silent_mutation.py
+++ b/tests/translators/test_silent_mutation.py
@@ -11,6 +11,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestSilentMutationTranslator(TranslatorBase, unittest.TestCase):
@@ -28,7 +29,8 @@ class TestSilentMutationTranslator(TranslatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return SM_V(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/translators/translator_base.py
+++ b/tests/translators/translator_base.py
@@ -1,7 +1,9 @@
 """A module for testing translator classes."""
 import yaml
 from tests import PROJECT_ROOT
-from variation.tokenizers import Tokenize
+from variation.tokenizers import Tokenize, GeneSymbol
+from variation.tokenizers.caches import AminoAcidCache
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TranslatorBase:
@@ -15,7 +17,9 @@ class TranslatorBase:
             self.fixture_name(),
             {'tests': []}
         )
-        self.tokenizer = Tokenize()
+        amino_acid_cache = AminoAcidCache()
+        gene_symbol = GeneSymbol(GeneQueryHandler())
+        self.tokenizer = Tokenize(amino_acid_cache, gene_symbol)
         self.classifier = self.classifier_instance()
         self.validator = self.validator_instance()
         self.translator = self.translator_instance()

--- a/tests/validators/test_amino_acid_deletion.py
+++ b/tests/validators/test_amino_acid_deletion.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidDeletionValidator(ValidatorBase, unittest.TestCase):
@@ -23,7 +24,8 @@ class TestAminoAcidDeletionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AminoAcidDeletion(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/validators/test_amino_acid_delins.py
+++ b/tests/validators/test_amino_acid_delins.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidDelInsValidator(ValidatorBase, unittest.TestCase):
@@ -23,7 +24,8 @@ class TestAminoAcidDelInsValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AminoAcidDelIns(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/validators/test_amino_acid_insertion.py
+++ b/tests/validators/test_amino_acid_insertion.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidInsertionValidator(ValidatorBase, unittest.TestCase):
@@ -23,7 +24,8 @@ class TestAminoAcidInsertionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AminoAcidInsertion(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/validators/test_amino_acid_substitution.py
+++ b/tests/validators/test_amino_acid_substitution.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestAminoAcidSubstitutionValidator(ValidatorBase, unittest.TestCase):
@@ -23,7 +24,8 @@ class TestAminoAcidSubstitutionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return AminoAcidSubstitution(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/validators/test_coding_dna_deletion.py
+++ b/tests/validators/test_coding_dna_deletion.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNADeletionValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestCodingDNADeletionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CodingDNADeletion(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_coding_dna_delins.py
+++ b/tests/validators/test_coding_dna_delins.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNADelInsValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestCodingDNADelInsValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CodingDNADelIns(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_coding_dna_insertion.py
+++ b/tests/validators/test_coding_dna_insertion.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNAInsertionValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestCodingDNAInsertionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CodingDNAInsertion(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_coding_dna_silent_mutation.py
+++ b/tests/validators/test_coding_dna_silent_mutation.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNASilentMutationValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestCodingDNASilentMutationValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CodingDNASilentMutation(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_coding_dna_subsitution.py
+++ b/tests/validators/test_coding_dna_subsitution.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestCodingDNASubstitutionValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestCodingDNASubstitutionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return CodingDNASubstitution(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_genomic_deletion.py
+++ b/tests/validators/test_genomic_deletion.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicDeletionValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestGenomicDeletionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GenomicDeletion(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_genomic_delins.py
+++ b/tests/validators/test_genomic_delins.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicDelInsValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestGenomicDelInsValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GenomicDelIns(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_genomic_insertion.py
+++ b/tests/validators/test_genomic_insertion.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicInsertionValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestGenomicInsertionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GenomicInsertion(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_genomic_silent_mutation.py
+++ b/tests/validators/test_genomic_silent_mutation.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicSilentMutationValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestGenomicSilentMutationValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GenomicSilentMutation(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_genomic_substitution.py
+++ b/tests/validators/test_genomic_substitution.py
@@ -9,6 +9,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestGenomicSubstitutionValidator(ValidatorBase, unittest.TestCase):
@@ -22,7 +23,8 @@ class TestGenomicSubstitutionValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return GenomicSubstitution(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr

--- a/tests/validators/test_polypeptide_truncation.py
+++ b/tests/validators/test_polypeptide_truncation.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestPolypeptideTruncationValidator(ValidatorBase, unittest.TestCase):
@@ -23,7 +24,8 @@ class TestPolypeptideTruncationValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return PolypeptideTruncation(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/validators/test_silent_mutation.py
+++ b/tests/validators/test_silent_mutation.py
@@ -10,6 +10,7 @@ from variation.data_sources import TranscriptMappings, SeqRepoAccess, \
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class TestSilentMutationValidator(ValidatorBase, unittest.TestCase):
@@ -23,7 +24,8 @@ class TestSilentMutationValidator(ValidatorBase, unittest.TestCase):
         dp = SeqRepoDataProxy(seqrepo_access.seq_repo_client)
         tlr = Translator(data_proxy=dp)
         return SilentMutation(
-            seqrepo_access, transcript_mappings, GeneSymbol(),
+            seqrepo_access, transcript_mappings,
+            GeneSymbol(GeneQueryHandler()),
             MANETranscript(seqrepo_access, transcript_mappings,
                            MANETranscriptMappings(), uta),
             uta, dp, tlr, AminoAcidCache())

--- a/tests/validators/validator_base.py
+++ b/tests/validators/validator_base.py
@@ -1,7 +1,9 @@
 """A module for testing validator classes."""
 import yaml
 from tests import PROJECT_ROOT
-from variation.tokenizers import Tokenize
+from variation.tokenizers import Tokenize, GeneSymbol
+from variation.tokenizers.caches import AminoAcidCache
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class ValidatorBase:
@@ -15,7 +17,8 @@ class ValidatorBase:
             self.fixture_name(),
             {'should_match': [], 'should_not_match': []}
         )
-        self.tokenizer = Tokenize()
+        self.tokenizer = Tokenize(AminoAcidCache(),
+                                  GeneSymbol(GeneQueryHandler()))
         self.classifier = self.classifier_instance()
         self.validator = self.validator_instance()
 

--- a/variation/__init__.py
+++ b/variation/__init__.py
@@ -28,11 +28,6 @@ if 'VARIATION_NORM_EB_PROD' in environ:
     ch.setLevel(logging.INFO)
     logger.addHandler(ch)
 
-# Default DynamoDB url is http://localhost:8000
-# To use a different connection, set `GENE_NORM_DB_URL`
-from gene.query import QueryHandler as GeneQueryHandler  # noqa: E402, F811
-GENE_NORMALIZER = GeneQueryHandler()
-
 
 def data_download(path, domain, dir, fn):
     """Download files using FTP.

--- a/variation/mane_transcript.py
+++ b/variation/mane_transcript.py
@@ -530,11 +530,7 @@ class MANETranscript:
             else:
                 return None
         chromosome, assembly = descr
-
-        if start_pos == end_pos:
-            is_same_pos = True
-        else:
-            is_same_pos = False
+        is_same_pos = start_pos == end_pos
 
         # Coordinate liftover
         if assembly < 'GRCh37':

--- a/variation/normalize.py
+++ b/variation/normalize.py
@@ -1,22 +1,29 @@
 """Module for Variation Normalization."""
 from typing import Optional, List, Tuple
-from variation import GENE_NORMALIZER
 from variation.schemas.ga4gh_vrsatile import VariationDescriptor
 from variation.schemas.ga4gh_vrs import Text
 from variation.data_sources import SeqRepoAccess, UTA
 from urllib.parse import quote
 from variation import logger
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class Normalize:
     """The Normalize class used to normalize a given variation."""
 
-    def __init__(self, seqrepo_access: SeqRepoAccess, uta: UTA):
-        """Initialize Normalize class."""
+    def __init__(self, seqrepo_access: SeqRepoAccess, uta: UTA,
+                 gene_normalizer: GeneQueryHandler) -> None:
+        """Initialize Normalize class.
+
+        :param SeqRepoAccess seqrepo_access: Access to SeqRepo data queries
+        :param UTA uta: Access to UTA database and queries
+        :parm QueryHandler gene_normalizer: Access to gene-normalizer queries
+        """
         self.seqrepo_access = seqrepo_access
         self.uta = uta
         self.warnings = list()
         self._gene_norm_cache = dict()
+        self.gene_normalizer = gene_normalizer
 
     def normalize(self, q, validations, warnings):
         """Normalize a given variation.
@@ -101,7 +108,7 @@ class Normalize:
         if gene_symbol in self._gene_norm_cache:
             return self._gene_norm_cache[gene_symbol]
         else:
-            response = GENE_NORMALIZER.normalize(gene_symbol)
+            response = self.gene_normalizer.normalize(gene_symbol)
             if 'gene_descriptor' in response and response['gene_descriptor']:
                 gene_descriptor = response['gene_descriptor']
                 self._gene_norm_cache[gene_symbol] = gene_descriptor

--- a/variation/query.py
+++ b/variation/query.py
@@ -1,0 +1,118 @@
+"""This module provides methods for handling queries."""
+from typing import Tuple, Optional, List
+from gene.query import QueryHandler as GeneQueryHandler
+from ga4gh.vrs.dataproxy import SeqRepoDataProxy
+from ga4gh.vrs.extras.translator import Translator
+from variation import SEQREPO_DATA_PATH, TRANSCRIPT_MAPPINGS_PATH, \
+    REFSEQ_GENE_SYMBOL_PATH, AMINO_ACID_PATH, UTA_DB_URL, REFSEQ_MANE_PATH
+from variation.schemas.ga4gh_vrsatile import VariationDescriptor
+from variation.to_vrs import ToVRS
+from variation.normalize import Normalize
+from variation.classifiers import Classify
+from variation.tokenizers import Tokenize
+from variation.validators import Validate
+from variation.translators import Translate
+from variation.data_sources import SeqRepoAccess, TranscriptMappings, \
+    UTA, MANETranscriptMappings
+from variation.mane_transcript import MANETranscript
+from variation.tokenizers import GeneSymbol
+from variation.tokenizers.caches import AminoAcidCache
+from variation.schemas.ga4gh_vrs import Text, Allele
+
+
+class QueryHandler:
+    """Class for handling queries."""
+
+    def __init__(self,
+                 dynamodb_url: str = '',
+                 dynamodb_region: str = 'us-east-2',
+                 seqrepo_data_path=SEQREPO_DATA_PATH,
+                 uta_db_url=UTA_DB_URL,
+                 uta_db_pwd=None) -> None:
+        """Initialize QueryHandler instance.
+        :param str dynamodb_url: URL to gene-normalizer database source.
+        :param str dynamodb_region: AWS default region for gene-normalizer.
+        :param str seqrepo_data_path: Path to seqrepo data directory
+        :param str uta_db_url: URL for UTA database
+        :param str uta_db_pwd: Password for UTA database user
+        """
+        self.gene_normalizer = GeneQueryHandler(db_url=dynamodb_url,
+                                                db_region=dynamodb_region)
+        self.seqrepo_access = SeqRepoAccess(
+            seqrepo_data_path=seqrepo_data_path
+        )
+        self.uta = UTA(db_url=uta_db_url, db_pwd=uta_db_pwd)
+        self.to_vrs_handler = self._init_to_vrs()
+        self.normalize_handler = Normalize(
+            self.seqrepo_access, self.uta, self.gene_normalizer
+        )
+
+    def _init_to_vrs(self, transcript_file_path=TRANSCRIPT_MAPPINGS_PATH,
+                     refseq_file_path=REFSEQ_GENE_SYMBOL_PATH,
+                     amino_acids_file_path=AMINO_ACID_PATH,
+                     mane_data_path=REFSEQ_MANE_PATH) -> ToVRS:
+        """Return toVRS instance
+
+        :param str transcript_file_path: Path to transcript mappings file
+        :param str refseq_file_path: Path to refseq gene symbol file
+        :param str amino_acids_file_path: Path to amino acids file
+        :param str mane_data_path: Path to refseq mane data file
+        :return: toVRS instance
+        """
+        gene_symbol = GeneSymbol(self.gene_normalizer)
+        amino_acid_cache = AminoAcidCache(
+            amino_acids_file_path=amino_acids_file_path
+        )
+        tokenizer = Tokenize(amino_acid_cache, gene_symbol)
+        classifier = Classify()
+        transcript_mappings = TranscriptMappings(
+            transcript_file_path=transcript_file_path,
+            refseq_file_path=refseq_file_path
+        )
+        mane_transcript_mappings = MANETranscriptMappings(
+            mane_data_path=mane_data_path
+        )
+        dp = SeqRepoDataProxy(self.seqrepo_access.seq_repo_client)
+        tlr = Translator(data_proxy=dp)
+        mane_transcript = MANETranscript(
+            self.seqrepo_access, transcript_mappings,
+            mane_transcript_mappings, self.uta
+        )
+        validator = Validate(
+            self.seqrepo_access, transcript_mappings, gene_symbol,
+            mane_transcript, self.uta, dp, tlr, amino_acid_cache
+        )
+        translator = Translate()
+        return ToVRS(
+            tokenizer, classifier, self.seqrepo_access, transcript_mappings,
+            gene_symbol, amino_acid_cache, self.uta, mane_transcript_mappings,
+            mane_transcript, validator, translator
+        )
+
+    def to_vrs(self, q) -> Tuple[Optional[List[Allele]], Optional[List[str]]]:
+        """Return a VRS-like representation of all validated variations for a query.  # noqa: E501
+
+        :param str q: The variation to translate
+        :return: Validated VRS Variations and list of warnings
+        """
+        validations, warnings = \
+            self.to_vrs_handler.get_validations(q)
+        translations, warnings = \
+            self.to_vrs_handler.get_translations(validations, warnings)
+
+        if not translations:
+            if q and q.strip():
+                translations = [Text(definition=q)]
+            else:
+                translations = None
+        return translations, warnings
+
+    def normalize(self, q) -> VariationDescriptor:
+        """Return normalized Variation Descriptor for variation.
+
+        :param q: Variation to normalize
+        :return: Variation Descriptor for variation
+        """
+        validations, warnings = \
+            self.to_vrs_handler.get_validations(q, normalize_endpoint=True)
+        return self.normalize_handler.normalize(q, validations, warnings)

--- a/variation/tokenizers/gene_pair.py
+++ b/variation/tokenizers/gene_pair.py
@@ -4,6 +4,7 @@ from .tokenizer import Tokenizer
 from .gene_symbol import GeneSymbol
 from variation.schemas.token_response_schema import GenePairMatchToken, \
     TokenMatchType
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class GenePair(Tokenizer):
@@ -11,7 +12,7 @@ class GenePair(Tokenizer):
 
     def __init__(self) -> None:
         """Initialize the Gene Pair class."""
-        self.__gene_matcher = GeneSymbol()
+        self.__gene_matcher = GeneSymbol(GeneQueryHandler())
 
     def match(self, input_string: str) -> Optional[GenePairMatchToken]:
         """Return tokens that match the input string."""

--- a/variation/tokenizers/gene_symbol.py
+++ b/variation/tokenizers/gene_symbol.py
@@ -4,15 +4,19 @@ from gene.schemas import MatchType
 from .tokenizer import Tokenizer
 from variation.schemas.token_response_schema import GeneMatchToken, \
     TokenMatchType
-from variation import GENE_NORMALIZER
+from gene.query import QueryHandler as GeneQueryHandler
 
 
 class GeneSymbol(Tokenizer):
     """Class for gene symbol tokenization."""
 
-    def __init__(self) -> None:
-        """Initialize the gene symbol tokenizer class."""
-        self.gene_normalizer = GENE_NORMALIZER
+    def __init__(self, gene_normalizer: GeneQueryHandler) -> None:
+        """Initialize the gene symbol tokenizer class.
+
+        :param QueryHandler gene_normalizer: Instance to gene normalizer
+            QueryHandler
+        """
+        self.gene_normalizer = gene_normalizer
         self._gene_cache = dict()
 
     def match(self, input_string: str) -> Optional[GeneMatchToken]:

--- a/variation/tokenizers/tokenize.py
+++ b/variation/tokenizers/tokenize.py
@@ -35,17 +35,15 @@ from .amino_acid_insertion import AminoAcidInsertion
 from .coding_dna_insertion import CodingDNAInsertion
 from .genomic_insertion import GenomicInsertion
 from variation.schemas.token_response_schema import Token, TokenMatchType
-from .caches import AminoAcidCache, NucleotideCache
+from .caches import NucleotideCache
 
 
 class Tokenize:
     """The tokenize class."""
 
-    def __init__(self) -> None:
+    def __init__(self, amino_acid_cache, gene_symbol: GeneSymbol) -> None:
         """Initialize the tokenize class."""
-        amino_acid_cache = AminoAcidCache()
         nucleotide_cache = NucleotideCache()
-
         self.tokenizers = (
             HGVS(),
             ReferenceSequence(),
@@ -57,7 +55,7 @@ class Tokenize:
             # Fusion(),
             # GainOfFunction(),
             # GenePair(),
-            GeneSymbol(),
+            gene_symbol,
             # LossOfFunction(),
             # OverExpression(),
             # ProteinAlternate(amino_acid_cache),


### PR DESCRIPTION
Realized how messy initializing everything was when using variation-normalizer in MetaKB, so formatted query handling similar to other normalizers