### PR TITLE
Share hgvs_parser as class variable

### DIFF
--- a/variation/mane_transcript.py
+++ b/variation/mane_transcript.py
@@ -9,7 +9,6 @@ Steps:
 4. Map back to correct annotation layer
 """
 from typing import Optional, Tuple, Dict
-import hgvs.parser
 import logging
 import math
 from pydantic.types import StrictBool
@@ -34,7 +33,6 @@ class MANETranscript:
             transcript alignments
         """
         self.seqrepo_access = seqrepo_access
-        self.hgvs_parser = hgvs.parser.Parser()
         self.transcript_mappings = transcript_mappings
         self.mane_transcript_mappings = mane_transcript_mappings
         self.uta = uta

--- a/variation/validators/validator.py
+++ b/variation/validators/validator.py
@@ -29,6 +29,8 @@ logger.setLevel(logging.DEBUG)
 class Validator(ABC):
     """The validator class."""
 
+    hgvs_parser = hgvs.parser.Parser()
+
     def __init__(self, seqrepo_access: SeqRepoAccess,
                  transcript_mappings: TranscriptMappings,
                  gene_symbol: GeneSymbol,
@@ -54,7 +56,6 @@ class Validator(ABC):
         self._gene_matcher = gene_symbol
         self.dp = dp
         self.tlr = tlr
-        self.hgvs_parser = hgvs.parser.Parser()
         self.uta = uta
         self.genomic_base = GenomicBase(self.dp, self.uta)
         self.mane_transcript = mane_transcript

--- a/variation/validators/validator.py
+++ b/variation/validators/validator.py
@@ -13,7 +13,6 @@ from variation.data_sources import SeqRepoAccess, TranscriptMappings
 from variation.mane_transcript import MANETranscript
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import Translator
-import hgvs.parser
 import logging
 from variation.validators.genomic_base import GenomicBase
 from variation.data_sources import UTA
@@ -28,8 +27,6 @@ logger.setLevel(logging.DEBUG)
 
 class Validator(ABC):
     """The validator class."""
-
-    hgvs_parser = hgvs.parser.Parser()
 
     def __init__(self, seqrepo_access: SeqRepoAccess,
                  transcript_mappings: TranscriptMappings,


### PR DESCRIPTION
A few notes

- in cProfile this reduces the startup time for QueryHandler by 40ish seconds (from 55 to 15 roughly)
- A couple of my tests aren't passing in staging or main and are also not passing on this branch so I didn't want to get too fancy, but you could also trim a couple more seconds off by sharing the HGVS Parser object between the MANE transcript class and the Validator classes
- I might have skimmed too quickly but I didn't see where `hgvs_parser` was actually being used, but maybe more focused tests at wherever that is would be appropriate?