### PR TITLE
Add `relative_cnv` to HGVS Dup Del Mode

### DIFF
--- a/docs/hgvs_dup_del_mode.md
+++ b/docs/hgvs_dup_del_mode.md
@@ -6,19 +6,13 @@ The mode can be set to `default`, `absolute_cnv`, `relative_cnv`, `repeated_seq_
 
 ## Default Characteristics
 
-- If endpoints are ambiguous: absolute_cnv (copies attribute)
-    - handling X chromosome
-        - base 1-2
-            - Duplication: Definite Range =  2, 3
-            - Deletion: Definite Range =  0, 1
-    - handling Y chromosome
-        - base of 1
-            - Duplication: Number = 2
-            - Deletion: Number = 0
-    - handling 1 – 22 chromosome
-        - base of 2
-             - Duplication: Number = 3
-             - Deletion: Number = 1
+- if baseline_copies is not set and endpoints are ambiguous:
+    - relative_cnv
+    - if relative_copy_class not provided:
+        - relative_copy_class = `partial loss` if del, `low-level gain` if dup
+elif baseline_copies is provided:
+    - absolute_cnv
+    - copies are baseline_copies + 1 for dup, baseline_copies - 1 for del
 - elif len del or dup > 100bp: (use outermost coordinates)
     - repeated_seq_expr with a derived_seq_expr subject (Allele)
 - else:

--- a/docs/hgvs_dup_del_mode.md
+++ b/docs/hgvs_dup_del_mode.md
@@ -1,26 +1,28 @@
 # HGVS Dup Del Mode
 
-This mode helps us interpret deletions and duplications that are represented as HGVS expressions.
+This mode helps us interpret deletions and duplications that are represented as HGVS expressions.\
+The mode can be set to `default`, `absolute_cnv`, `relative_cnv`, `repeated_seq_expr`, or `literal_seq_expr`.
+
 
 ## Default Characteristics
 
-- If endpoints are ambiguous: cnv (copies attribute) 
-    - handling X chromosome 
-        - base 1-2 
-            - Duplication: Definite Range =  2, 3 
-            - Deletion: Definite Range =  0, 1 
-    - handling Y chromosome 
-        - base of 1  
-            - Duplication: Number = 2 
-            - Deletion: Number = 0 
-    - handling 1 – 22 chromosome 
-        - base of 2 
-             - Duplication: Number = 3 
-             - Deletion: Number = 1 
-- elif len del or dup > 100bp: (use outermost coordinates) 
-    - repeated_seq_expr with a derived_seq_expr subject (Allele) 
-- else: 
-    - literal_seq_expr (normalized LiteralSequenceExpression Allele) 
+- If endpoints are ambiguous: absolute_cnv (copies attribute)
+    - handling X chromosome
+        - base 1-2
+            - Duplication: Definite Range =  2, 3
+            - Deletion: Definite Range =  0, 1
+    - handling Y chromosome
+        - base of 1
+            - Duplication: Number = 2
+            - Deletion: Number = 0
+    - handling 1 – 22 chromosome
+        - base of 2
+             - Duplication: Number = 3
+             - Deletion: Number = 1
+- elif len del or dup > 100bp: (use outermost coordinates)
+    - repeated_seq_expr with a derived_seq_expr subject (Allele)
+- else:
+    - literal_seq_expr (normalized LiteralSequenceExpression Allele)
 
 # Notes
 
@@ -31,3 +33,5 @@ This mode helps us interpret deletions and duplications that are represented as 
     - `#_(#_?)`
 - We do not normalize any ambiguous ranges
 - We do not change the molecular context for ambiguous ranges.
+- The `/to_vrs` endpoint uses the default mode for HGVS deletions and duplications.
+- The `/normalize` endpoint uses the default mode for HGVS deletions and duplications if a mode is not set.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -645,7 +645,7 @@ def genoimc_dup4_loc():
 
 
 @pytest.fixture(scope="session")
-def genoimc_dup5_loc():
+def genomic_dup5_loc():
     """Create genoimc dup5 sequence location"""
     return {
         "_id": "ga4gh:VSL.k2FXLyqyS8pbtZxEHCpNd2SHD6iCtH9C",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -808,20 +808,26 @@ def genomic_del6_seq_loc():
 
 
 @pytest.fixture(scope="session")
-def grch38_genomic_insertion_variation():
+def grch38_genomic_insertion_seq_loc():
+    """Create test fixture for GRCh38 genomic insertioni seq location"""
+    return {
+        "_id": "ga4gh:VSL.fJ80Ab9JP0GXtDNeEaoDxE35tlI-k9Cd",
+        "interval": {
+            "end": {"value": 39724743, "type": "Number"},
+            "start": {"value": 39724731, "type": "Number"},
+            "type": "SequenceInterval"
+        },
+        "sequence_id": "ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7",
+        "type": "SequenceLocation"
+    }
+
+
+@pytest.fixture(scope="session")
+def grch38_genomic_insertion_variation(grch38_genomic_insertion_seq_loc):
     """Create a test fixture for NC_000017.10:g.37880993_37880994insGCTTACGTGATG"""
     return {
         "_id": "ga4gh:VA.tCjV190dUsV7tSjdR8qOLSQIR7Hr8VMe",
-        "location": {
-            "_id": "ga4gh:VSL.fJ80Ab9JP0GXtDNeEaoDxE35tlI-k9Cd",
-            "interval": {
-                "end": {"value": 39724743, "type": "Number"},
-                "start": {"value": 39724731, "type": "Number"},
-                "type": "SequenceInterval"
-            },
-            "sequence_id": "ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7",
-            "type": "SequenceLocation"
-        },
+        "location": grch38_genomic_insertion_seq_loc,
         "state": {
             "sequence": "TACGTGATGGCTTACGTGATGGCT",
             "type": "LiteralSequenceExpression"

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -220,8 +220,8 @@ def genomic_dup1():
 
 
 @pytest.fixture(scope="module")
-def genomic_dup1_default(genomic_dup1, genomic_dup1_seq_loc):
-    """Create a test fixture for genomic dup default and LSE."""
+def genomic_dup1_lse(genomic_dup1, genomic_dup1_seq_loc):
+    """Create a test fixture for genomic dup LSE."""
     _id = "ga4gh:VA.aeNse-a8IJzqHiG-P5zTRYA_eVFhrJXw"
     genomic_dup1["variation_id"] = _id
     genomic_dup1["variation"] = {
@@ -237,8 +237,8 @@ def genomic_dup1_default(genomic_dup1, genomic_dup1_seq_loc):
 
 
 @pytest.fixture(scope="module")
-def genomic_dup1_cnv(genomic_dup1, genomic_dup1_38_vac):
-    """Create a test fixture for genomic dup CNV."""
+def genomic_dup1_vac(genomic_dup1, genomic_dup1_38_vac):
+    """Create a test fixture for genomic dup absolute CNV."""
     genomic_dup1["variation"] = genomic_dup1_38_vac
     genomic_dup1["variation_id"] = genomic_dup1["variation"]["_id"]
     return VariationDescriptor(**genomic_dup1)
@@ -379,9 +379,9 @@ def genomic_dup1_free_text_seq_loc():
 
 
 @pytest.fixture(scope="module")
-def genomic_dup1_free_text_default(genomic_dup1_free_text,
-                                   genomic_dup1_free_text_seq_loc):
-    """Create a test fixture for genomic dup default and LSE."""
+def genomic_dup1_free_text_lse(genomic_dup1_free_text,
+                               genomic_dup1_free_text_seq_loc):
+    """Create a test fixture for genomic dup LSE."""
     _id = "ga4gh:VA.eE5Kr1zJrv3PSXeBabbKTFnZxToaYxat"
     genomic_dup1_free_text["variation_id"] = _id
     genomic_dup1_free_text["variation"] = {
@@ -397,9 +397,9 @@ def genomic_dup1_free_text_default(genomic_dup1_free_text,
 
 
 @pytest.fixture(scope="module")
-def genomic_dup1_free_text_cnv(genomic_dup1_free_text,
+def genomic_dup1_free_text_vac(genomic_dup1_free_text,
                                genomic_dup1_free_text_seq_loc):
-    """Create a test fixture for genomic dup CNV."""
+    """Create a test fixture for genomic dup absolute CNV."""
     _id = "ga4gh:VAC.qeuDGWVaGZUOf7XmF2xO1k24LvFzGVE1"
     genomic_dup1_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
@@ -453,8 +453,8 @@ def genomic_dup2():
 
 
 @pytest.fixture(scope="module")
-def genomic_dup2_default(genomic_dup2, genomic_dup2_seq_loc):
-    """Create a test fixture for genomic dup default and LSE."""
+def genomic_dup2_lse(genomic_dup2, genomic_dup2_seq_loc):
+    """Create a test fixture for genomic dup LSE."""
     _id = "ga4gh:VA.wqqxfUCrFSndedI2-4oiIuHLHHGjBFof"
     genomic_dup2["variation_id"] = _id
     genomic_dup2["variation"] = {
@@ -470,8 +470,8 @@ def genomic_dup2_default(genomic_dup2, genomic_dup2_seq_loc):
 
 
 @pytest.fixture(scope="module")
-def genomic_dup2_cnv(genomic_dup2, genomic_dup2_38_vac):
-    """Create a test fixture for genomic dup CNV."""
+def genomic_dup2_vac(genomic_dup2, genomic_dup2_38_vac):
+    """Create a test fixture for genomic dup absolute CNV."""
     genomic_dup2["variation"] = genomic_dup2_38_vac
     genomic_dup2["variation_id"] = genomic_dup2["variation"]["_id"]
     return VariationDescriptor(**genomic_dup2)
@@ -552,15 +552,15 @@ def genomic_dup2_free_text_default(genomic_dup2_free_text,
 
 
 @pytest.fixture(scope="module")
-def genomic_dup2_free_text_cnv(genomic_dup2_free_text,
+def genomic_dup2_free_text_vac(genomic_dup2_free_text,
                                genomic_dup2_free_text_seq_loc):
-    """Create a test fixture for genomic dup CNV."""
-    _id = "ga4gh:VAC.1X1mLzx7HshdOPfBzeBSKRX41IGh8DId"
+    """Create a test fixture for genomic dup absolute CNV."""
+    _id = "ga4gh:VAC.p538XMNKHyZGEVb73xbA2DfSxSJOZG4B"
     genomic_dup2_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
         "subject": genomic_dup2_free_text_seq_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 3}
     }
     genomic_dup2_free_text["variation_id"] = _id
     return VariationDescriptor(**genomic_dup2_free_text)
@@ -608,14 +608,28 @@ def genomic_dup3():
 
 
 @pytest.fixture(scope="module")
-def genomic_dup3_default(genomic_dup3, genomic_del3_dup3_loc):
-    """Create a test fixture for genomic dup default and cnv."""
-    _id = "ga4gh:VAC.dvalAo00K9zGaI4lbxATjGTuNImbAefX"
+def genomic_dup3_vac(genomic_dup3, genomic_del3_dup3_loc):
+    """Create a test fixture for genomic dup absolute cnv."""
+    _id = "ga4gh:VAC.cQATJ6a1uGwXOHu-advv8lRsMgjNLKul"
     genomic_dup3["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
         "subject": genomic_del3_dup3_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 2}
+    }
+    genomic_dup3["variation_id"] = _id
+    return VariationDescriptor(**genomic_dup3)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup3_vrc(genomic_dup3, genomic_del3_dup3_loc):
+    """Create a test fixture for genomic dup relative cnv."""
+    _id = "ga4gh:VRC.APoRHUv3_v5FSbtfU5DuESzF9iuDLdYx"
+    genomic_dup3["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del3_dup3_loc,
+        "relative_copy_class": "low-level gain"
     }
     genomic_dup3["variation_id"] = _id
     return VariationDescriptor(**genomic_dup3)
@@ -653,31 +667,51 @@ def genomic_dup3_free_text(dmd_gene_context):
 
 
 @pytest.fixture(scope="module")
-def genomic_dup3_free_text_default(genomic_dup3_free_text):
-    """Create a test fixture for genomic dup default and cnv."""
-    _id = "ga4gh:VAC.2i0YEoNp5g0GLOW_WGrLKIyeG9G1tSDO"
+def genomic_dup3_free_text_subject():
+    """Create test fixture for genomic dup3 free text subject"""
+    return {
+        "_id": "ga4gh:VSL.6JRgXRroqGleDLuwmOdHSbUK8Lm27fos",
+        "sequence_id": "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        "interval": {
+            "type": "SequenceInterval",
+            "start": {
+                "min": 31147273,
+                "max": 31147277,
+                "type": "DefiniteRange"
+            },
+            "end": {
+                "min": 31182738,
+                "max": 31182740,
+                "type": "DefiniteRange"
+            }
+        },
+        "type": "SequenceLocation"
+    }
+
+
+@pytest.fixture(scope="module")
+def genomic_dup3_free_text_vrc(genomic_dup3_free_text, genomic_dup3_free_text_subject):
+    """Create a test fixture for genomic dup relative cnv."""
+    _id = "ga4gh:VRC.0-oCLK0W3ND8-EzZsRJUJlF5MTe3VgSD"
+    genomic_dup3_free_text["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_dup3_free_text_subject,
+        "relative_copy_class": "low-level gain"
+    }
+    genomic_dup3_free_text["variation_id"] = _id
+    return VariationDescriptor(**genomic_dup3_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup3_free_text_vac(genomic_dup3_free_text, genomic_dup3_free_text_subject):
+    """Create a test fixture for genomic dup absolute cnv."""
+    _id = "ga4gh:VAC.WwO4IBA5qODo__32hAMeV8cb1q5uZyqd"
     genomic_dup3_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
-        "subject": {
-            "_id": "ga4gh:VSL.6JRgXRroqGleDLuwmOdHSbUK8Lm27fos",
-            "sequence_id": "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
-            "interval": {
-                "type": "SequenceInterval",
-                "start": {
-                    "min": 31147273,
-                    "max": 31147277,
-                    "type": "DefiniteRange"
-                },
-                "end": {
-                    "min": 31182738,
-                    "max": 31182740,
-                    "type": "DefiniteRange"
-                }
-            },
-            "type": "SequenceLocation"
-        },
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "subject": genomic_dup3_free_text_subject,
+        "copies": {"type": "Number", "value": 4}
     }
     genomic_dup3_free_text["variation_id"] = _id
     return VariationDescriptor(**genomic_dup3_free_text)
@@ -714,8 +748,22 @@ def genomic_dup4():
 
 
 @pytest.fixture(scope="module")
-def genomic_dup4_default(genomic_dup4, genoimc_dup4_loc):
-    """Create a test fixture for genomic dup default and cnv."""
+def genomic_dup4_vrc(genomic_dup4, genoimc_dup4_loc):
+    """Create a test fixture for genomic dup relative cnv."""
+    _id = "ga4gh:VRC.9N_ih-YzkKM91k6adSGQuGce5t4nJspV"
+    genomic_dup4["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genoimc_dup4_loc,
+        "relative_copy_class": "low-level gain"
+    }
+    genomic_dup4["variation_id"] = _id
+    return VariationDescriptor(**genomic_dup4)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup4_vac(genomic_dup4, genoimc_dup4_loc):
+    """Create a test fixture for genomic dup absolute cnv."""
     _id = "ga4gh:VAC.h594XLS8a4VA6j-ghLaghqXmof8hmF5z"
     genomic_dup4["variation"] = {
         "type": "AbsoluteCopyNumber",
@@ -842,30 +890,50 @@ def genomic_dup4_free_text():
 
 
 @pytest.fixture(scope="module")
-def genomic_dup4_free_text_default(genomic_dup4_free_text):
-    """Create a test fixture for genomic dup default and cnv."""
+def genomic_dup4_free_text_subject():
+    """Create test fixture for genomic dup4 free text subject"""
+    return {
+        "_id": "ga4gh:VSL.4eNCJnROfnoO-YvGnf-iGCeDHF_68g8H",
+        "sequence_id": "ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7",
+        "interval": {
+            "type": "SequenceInterval",
+            "start": {
+                "value": 1674441,
+                "comparator": "<=",
+                "type": "IndefiniteRange"
+            },
+            "end": {
+                "value": 1684571,
+                "comparator": ">=",
+                "type": "IndefiniteRange"
+            }
+        },
+        "type": "SequenceLocation"
+    }
+
+
+@pytest.fixture(scope="module")
+def genomic_dup4_free_text_vrc(genomic_dup4_free_text, genomic_dup4_free_text_subject):
+    """Create a test fixture for genomic dup relative cnv."""
+    _id = "ga4gh:VRC.JmhvBvSI2l_MPRhokZcjO8EPlqvU5V_g"
+    genomic_dup4_free_text["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_dup4_free_text_subject,
+        "relative_copy_class": "low-level gain"
+    }
+    genomic_dup4_free_text["variation_id"] = _id
+    return VariationDescriptor(**genomic_dup4_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup4_free_text_vac(genomic_dup4_free_text, genomic_dup4_free_text_subject):
+    """Create a test fixture for genomic dup absolute cnv."""
     _id = "ga4gh:VAC.G0SbODtFctpFS9aufQGvRuGNRTR_D37E"
     genomic_dup4_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
-        "subject": {
-            "_id": "ga4gh:VSL.4eNCJnROfnoO-YvGnf-iGCeDHF_68g8H",
-            "sequence_id": "ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7",
-            "interval": {
-                "type": "SequenceInterval",
-                "start": {
-                    "value": 1674441,
-                    "comparator": "<=",
-                    "type": "IndefiniteRange"
-                },
-                "end": {
-                    "value": 1684571,
-                    "comparator": ">=",
-                    "type": "IndefiniteRange"
-                }
-            },
-            "type": "SequenceLocation"
-        },
+        "subject": genomic_dup4_free_text_subject,
         "copies": {
             "type": "Number",
             "value": 3
@@ -905,22 +973,41 @@ def genomic_dup5():
     return params
 
 
-def genomic_dup5_copy_number(params, genoimc_dup5_loc):
-    """Create genomic dup5 copy number object"""
-    _id = "ga4gh:VAC.UwgjCJsg8XKPX8e2zhtw3jFfeUfgrGAZ"
+def genomic_dup5_abs_cnv(params, genomic_dup5_loc):
+    """Create genomic dup5 aboluste cnv"""
+    _id = "ga4gh:VAC.bAqgh0Ecs_NxhtrBUhhE8_GN6QCCN9Td"
     params["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
-        "subject": genoimc_dup5_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "subject": genomic_dup5_loc,
+        "copies": {"type": "Number", "value": 3}
+    }
+    params["variation_id"] = _id
+
+
+def genomic_dup5_rel_cnv(params, genomic_dup5_loc):
+    """Create genomic dup4 relative cnv"""
+    _id = "ga4gh:VRC.vWvFd5fM7Xa-unq_IO8OZUhYfHfOtSQ8"
+    params["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_dup5_loc,
+        "relative_copy_class": "low-level gain"
     }
     params["variation_id"] = _id
 
 
 @pytest.fixture(scope="module")
-def genomic_dup5_default(genomic_dup5, genoimc_dup5_loc):
-    """Create a test fixture for genomic dup default and cnv."""
-    genomic_dup5_copy_number(genomic_dup5, genoimc_dup5_loc)
+def genomic_dup5_vrc(genomic_dup5, genomic_dup5_loc):
+    """Create a test fixture for genomic dup5 relative cnv."""
+    genomic_dup5_rel_cnv(genomic_dup5, genomic_dup5_loc)
+    return VariationDescriptor(**genomic_dup5)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup5_vac(genomic_dup5, genomic_dup5_loc):
+    """Create a test fixture for genomic dup5 absolute cnv."""
+    genomic_dup5_abs_cnv(genomic_dup5, genomic_dup5_loc)
     return VariationDescriptor(**genomic_dup5)
 
 
@@ -956,9 +1043,16 @@ def genomic_dup5_free_text(mecp2_gene_context):
 
 
 @pytest.fixture(scope="module")
-def genomic_dup5_free_text_default(genomic_dup5_free_text, genoimc_dup5_loc):
-    """Create a test fixture for genomic dup default and cnv."""
-    genomic_dup5_copy_number(genomic_dup5_free_text, genoimc_dup5_loc)
+def genomic_dup5_free_text_vrc(genomic_dup5_free_text, genomic_dup5_loc):
+    """Create a test fixture for genomic dup relative cnv."""
+    genomic_dup5_rel_cnv(genomic_dup5_free_text, genomic_dup5_loc)
+    return VariationDescriptor(**genomic_dup5_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup5_free_text_vac(genomic_dup5_free_text, genomic_dup5_loc):
+    """Create a test fixture for genomic dup absolute cnv."""
+    genomic_dup5_abs_cnv(genomic_dup5_free_text, genomic_dup5_loc)
     return VariationDescriptor(**genomic_dup5_free_text)
 
 
@@ -992,22 +1086,41 @@ def genomic_dup6():
     return params
 
 
-def genomic_dup6_copy_number(params, genoimc_dup6_loc):
-    """Create genomic dup6 copy number object"""
-    _id = "ga4gh:VAC.vtHdiIdXvKO4z4M5x_26UoMN4HVW_Kh2"
+def genomic_dup6_rel_cnv(params, genoimc_dup6_loc):
+    """Create genomic dup6 relative cnv"""
+    _id = "ga4gh:VRC.YPZLS_Cld8CEkEveTafSmWfH_QyB3okT"
+    params["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genoimc_dup6_loc,
+        "relative_copy_class": "low-level gain"
+    }
+    params["variation_id"] = _id
+
+
+def genomic_dup6_abs_cnv(params, genoimc_dup6_loc):
+    """Create genomic dup6 absolute cnv"""
+    _id = "ga4gh:VAC.ZkgR6TD7VypzVrLAYFnSb-D7DXp62Yfn"
     params["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
         "subject": genoimc_dup6_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 2}
     }
     params["variation_id"] = _id
 
 
 @pytest.fixture(scope="module")
-def genomic_dup6_default(genomic_dup6, genoimc_dup6_loc):
-    """Create a test fixture for genomic dup default and cnv."""
-    genomic_dup6_copy_number(genomic_dup6, genoimc_dup6_loc)
+def genomic_dup6_vrc(genomic_dup6, genoimc_dup6_loc):
+    """Create a test fixture for genomic dup relative cnv."""
+    genomic_dup6_rel_cnv(genomic_dup6, genoimc_dup6_loc)
+    return VariationDescriptor(**genomic_dup6)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup6_vac(genomic_dup6, genoimc_dup6_loc):
+    """Create a test fixture for genomic dup absolute cnv."""
+    genomic_dup6_abs_cnv(genomic_dup6, genoimc_dup6_loc)
     return VariationDescriptor(**genomic_dup6)
 
 
@@ -1043,9 +1156,16 @@ def genomic_dup6_free_text(mecp2_gene_context):
 
 
 @pytest.fixture(scope="module")
-def genomic_dup6_free_text_default(genomic_dup6_free_text, genoimc_dup6_loc):
-    """Create a test fixture for genomic dup default and cnv."""
-    genomic_dup6_copy_number(genomic_dup6_free_text, genoimc_dup6_loc)
+def genomic_dup6_free_text_vrc(genomic_dup6_free_text, genoimc_dup6_loc):
+    """Create a test fixture for genomic dup relative cnv."""
+    genomic_dup6_rel_cnv(genomic_dup6_free_text, genoimc_dup6_loc)
+    return VariationDescriptor(**genomic_dup6_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup6_free_text_vac(genomic_dup6_free_text, genoimc_dup6_loc):
+    """Create a test fixture for genomic dup absolute cnv."""
+    genomic_dup6_abs_cnv(genomic_dup6_free_text, genoimc_dup6_loc)
     return VariationDescriptor(**genomic_dup6_free_text)
 
 
@@ -1080,8 +1200,8 @@ def genomic_del1():
 
 
 @pytest.fixture(scope="module")
-def genomic_del1_default(genomic_del1, genomic_del1_seq_loc):
-    """Create a test fixture for genomic del default and LSE."""
+def genomic_del1_lse(genomic_del1, genomic_del1_seq_loc):
+    """Create a test fixture for genomic del LSE."""
     _id = "ga4gh:VA.jUeT1n4AuBzwtt5TT-Iaac1KasATWjKE"
     genomic_del1["variation_id"] = _id
     genomic_del1["variation"] = {
@@ -1097,8 +1217,8 @@ def genomic_del1_default(genomic_del1, genomic_del1_seq_loc):
 
 
 @pytest.fixture(scope="module")
-def genomic_del1_cnv(genomic_del1, genomic_del1_38_vac):
-    """Create a test fixture for genomic del CNV."""
+def genomic_del1_vac(genomic_del1, genomic_del1_38_vac):
+    """Create a test fixture for genomic del absolute CNV."""
     genomic_del1["variation"] = genomic_del1_38_vac
     genomic_del1["variation_id"] = genomic_del1["variation"]["_id"]
     return VariationDescriptor(**genomic_del1)
@@ -1161,9 +1281,9 @@ def genomic_del1_free_text_seq_loc():
 
 
 @pytest.fixture(scope="module")
-def genomic_del1_free_text_default(genomic_del1_free_text,
-                                   genomic_del1_free_text_seq_loc):
-    """Create a test fixture for genomic del default and LSE."""
+def genomic_del1_free_text_lse(genomic_del1_free_text,
+                               genomic_del1_free_text_seq_loc):
+    """Create a test fixture for genomic del LSE."""
     _id = "ga4gh:VA.DdtLZ_d22R0O0VU020WcCLvNhXNZtU2j"
     genomic_del1_free_text["variation_id"] = _id
     genomic_del1_free_text["variation"] = {
@@ -1179,9 +1299,9 @@ def genomic_del1_free_text_default(genomic_del1_free_text,
 
 
 @pytest.fixture(scope="module")
-def genomic_del1_free_text_cnv(genomic_del1_free_text,
+def genomic_del1_free_text_vac(genomic_del1_free_text,
                                genomic_del1_free_text_seq_loc):
-    """Create a test fixture for genomic del CNV."""
+    """Create a test fixture for genomic del absolute CNV."""
     _id = "ga4gh:VAC.Wgvw8a4LXRY4d1jopC5tZjUlaEKci5Ai"
     genomic_del1_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
@@ -1235,8 +1355,8 @@ def genomic_del2():
 
 
 @pytest.fixture(scope="module")
-def genomic_del2_default(genomic_del2, genomic_del2_seq_loc):
-    """Create a test fixture for genomic del default and LSE."""
+def genomic_del2_lse(genomic_del2, genomic_del2_seq_loc):
+    """Create a test fixture for genomic del LSE."""
     _id = "ga4gh:VA.CSWNhR5w_geMmJTxkbO3UCLCvT0S2Ypx"
     genomic_del2["variation_id"] = _id
     genomic_del2["variation"] = {
@@ -1252,8 +1372,8 @@ def genomic_del2_default(genomic_del2, genomic_del2_seq_loc):
 
 
 @pytest.fixture(scope="module")
-def genomic_del2_cnv(genomic_del2, genomic_del2_38_vac):
-    """Create a test fixture for genomic del CNV."""
+def genomic_del2_vac(genomic_del2, genomic_del2_38_vac):
+    """Create a test fixture for genomic del absolute CNV."""
     genomic_del2["variation"] = genomic_del2_38_vac
     genomic_del2["variation_id"] = genomic_del2["variation"]["_id"]
     return VariationDescriptor(**genomic_del2)
@@ -1390,14 +1510,28 @@ def genomic_del3():
 
 
 @pytest.fixture(scope="module")
-def genomic_del3_default(genomic_del3, genomic_del3_dup3_loc):
-    """Create a test fixture for genomic del default and cnv."""
-    _id = "ga4gh:VAC.0ZYzw7KuXYv7a_TV3eF5qjRbqN0HvxBx"
+def genomic_del3_vrc(genomic_del3, genomic_del3_dup3_loc):
+    """Create a test fixture for genomic del relative cnv."""
+    _id = "ga4gh:VRC.7uGeBoQVduNHyz3dDmnTDaVsDhCMAaZe"
+    genomic_del3["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del3_dup3_loc,
+        "relative_copy_class": "partial loss"
+    }
+    genomic_del3["variation_id"] = _id
+    return VariationDescriptor(**genomic_del3)
+
+
+@pytest.fixture(scope="module")
+def genomic_del3_vac(genomic_del3, genomic_del3_dup3_loc):
+    """Create a test fixture for genomic del absolute cnv."""
+    _id = "ga4gh:VAC.cQATJ6a1uGwXOHu-advv8lRsMgjNLKul"
     genomic_del3["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
         "subject": genomic_del3_dup3_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 2}
     }
     genomic_del3["variation_id"] = _id
     return VariationDescriptor(**genomic_del3)
@@ -1520,31 +1654,51 @@ def genomic_del3_free_text():
 
 
 @pytest.fixture(scope="module")
-def genomic_del3_free_text_default(genomic_del3_free_text):
-    """Create a test fixture for genomic del default and cnv."""
-    _id = "ga4gh:VAC.7qHhQ6Ppm0JVpSpF8Hh8MW7msSJjfzq8"
+def genomic_del3_free_text_subject():
+    """Create test fixture for genomic del3 free text subject"""
+    return {
+        "_id": "ga4gh:VSL.gqWO-oN2bMIXm_YuZR4_beT57QN-kRGJ",
+        "sequence_id": "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        "interval": {
+            "type": "SequenceInterval",
+            "start": {
+                "min": 68839264,
+                "max": 68839267,
+                "type": "DefiniteRange"
+            },
+            "end": {
+                "min": 68841121,
+                "max": 68841126,
+                "type": "DefiniteRange"
+            }
+        },
+        "type": "SequenceLocation"
+    }
+
+
+@pytest.fixture(scope="module")
+def genomic_del3_free_text_vrc(genomic_del3_free_text, genomic_del3_free_text_subject):
+    """Create a test fixture for genomic del relative cnv."""
+    _id = "ga4gh:VRC.hHXnhBGUcR870shryKPt8qibKpaRjDE4"
+    genomic_del3_free_text["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del3_free_text_subject,
+        "relative_copy_class": "partial loss"
+    }
+    genomic_del3_free_text["variation_id"] = _id
+    return VariationDescriptor(**genomic_del3_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_del3_free_text_vac(genomic_del3_free_text, genomic_del3_free_text_subject):
+    """Create a test fixture for genomic del absolute cnv."""
+    _id = "ga4gh:VAC.14iSDwh4eU37jPuiBVZ_tdtRdQAqbjqG"
     genomic_del3_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
-        "subject": {
-            "_id": "ga4gh:VSL.gqWO-oN2bMIXm_YuZR4_beT57QN-kRGJ",
-            "sequence_id": "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
-            "interval": {
-                "type": "SequenceInterval",
-                "start": {
-                    "min": 68839264,
-                    "max": 68839267,
-                    "type": "DefiniteRange"
-                },
-                "end": {
-                    "min": 68841121,
-                    "max": 68841126,
-                    "type": "DefiniteRange"
-                }
-            },
-            "type": "SequenceLocation"
-        },
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "subject": genomic_del3_free_text_subject,
+        "copies": {"type": "Number", "value": 2}
     }
     genomic_del3_free_text["variation_id"] = _id
     return VariationDescriptor(**genomic_del3_free_text)
@@ -1581,14 +1735,28 @@ def genomic_del4():
 
 
 @pytest.fixture(scope="module")
-def genomic_del4_default(genomic_del4, genomic_del4_seq_loc):
-    """Create a test fixture for genomic del default and cnv."""
-    _id = "ga4gh:VAC.Dyccf3xmoPSN90ksXP2KAb5TuFIkgO6r"
+def genomic_del4_vrc(genomic_del4, genomic_del4_seq_loc):
+    """Create a test fixture for genomic del relative cnv."""
+    _id = "ga4gh:VRC.dtwRjvChZ6LuyDXyWTnVGQJidyfJsQfe"
+    genomic_del4["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del4_seq_loc,
+        "relative_copy_class": "partial loss"
+    }
+    genomic_del4["variation_id"] = _id
+    return VariationDescriptor(**genomic_del4)
+
+
+@pytest.fixture(scope="module")
+def genomic_del4_vac(genomic_del4, genomic_del4_seq_loc):
+    """Create a test fixture for genomic del absolute cnv."""
+    _id = "ga4gh:VAC.9AmYiW27hEz5V2fCisXqbFJpYeyGaZBv"
     genomic_del4["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
         "subject": genomic_del4_seq_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 1}
     }
     genomic_del4["variation_id"] = _id
     return VariationDescriptor(**genomic_del4)
@@ -1696,30 +1864,50 @@ def genomic_del4_free_text():
 
 
 @pytest.fixture(scope="module")
-def genomic_del4_free_text_default(genomic_del4_free_text):
-    """Create a test fixture for genomic del default and cnv."""
+def genomic_del4_free_text_subject():
+    """Create test fixture for genomic del4 free text subject"""
+    return {
+        "_id": "ga4gh:VSL.s4_6D986zFS0HIBuEDFl5aq2-VCl45h1",
+        "sequence_id": "ga4gh:SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g",
+        "interval": {
+            "type": "SequenceInterval",
+            "start": {
+                "value": 227022027,
+                "comparator": "<=",
+                "type": "IndefiniteRange"
+            },
+            "end": {
+                "value": 227025830,
+                "comparator": ">=",
+                "type": "IndefiniteRange"
+            }
+        },
+        "type": "SequenceLocation"
+    }
+
+
+@pytest.fixture(scope="module")
+def genomic_del4_free_text_vrc(genomic_del4_free_text, genomic_del4_free_text_subject):
+    """Create a test fixture for genomic del relative cnv."""
+    _id = "ga4gh:VRC.xNHxMmWtqOkKQS7hpJlCN4jjGgBsdk7b"
+    genomic_del4_free_text["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del4_free_text_subject,
+        "relative_copy_class": "partial loss"
+    }
+    genomic_del4_free_text["variation_id"] = _id
+    return VariationDescriptor(**genomic_del4_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_del4_free_text_vac(genomic_del4_free_text, genomic_del4_free_text_subject):
+    """Create a test fixture for genomic del absolute cnv."""
     _id = "ga4gh:VAC.DrUaDS4OCFqKSvvXhJse2PCduwnZMwkU"
     genomic_del4_free_text["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
-        "subject": {
-            "_id": "ga4gh:VSL.s4_6D986zFS0HIBuEDFl5aq2-VCl45h1",
-            "sequence_id": "ga4gh:SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g",
-            "interval": {
-                "type": "SequenceInterval",
-                "start": {
-                    "value": 227022027,
-                    "comparator": "<=",
-                    "type": "IndefiniteRange"
-                },
-                "end": {
-                    "value": 227025830,
-                    "comparator": ">=",
-                    "type": "IndefiniteRange"
-                }
-            },
-            "type": "SequenceLocation"
-        },
+        "subject": genomic_del4_free_text_subject,
         "copies": {"type": "Number", "value": 1}
     }
     genomic_del4_free_text["variation_id"] = _id
@@ -1747,9 +1935,9 @@ def genomic_uncertain_del_2():
     params = {
         "id": "normalize.variation:NC_000002.12%3Ag.%28%3F_110104900%29_%28110207160_%3F%29del",  # noqa: E501
         "type": "VariationDescriptor",
-        "variation_id": "ga4gh:VAC.aLkuetccbB2s18VjspHlBNpVkrdi5kgh",
+        "variation_id": "ga4gh:VRC.GYVDxHLsPXu54Ri8x2kFqRWhGBg1RgFc",
         "variation": {
-            "_id": "ga4gh:VAC.aLkuetccbB2s18VjspHlBNpVkrdi5kgh",
+            "_id": "ga4gh:VRC.GYVDxHLsPXu54Ri8x2kFqRWhGBg1RgFc",
             "subject": {
                 "_id": "ga4gh:VSL.75GQmJvq7dyP9-wom8Jffjk0Q9Le7Q9O",
                 "sequence_id": "ga4gh:SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g",
@@ -1768,11 +1956,8 @@ def genomic_uncertain_del_2():
                 },
                 "type": "SequenceLocation"
             },
-            "copies": {
-                "value": 1,
-                "type": "Number"
-            },
-            "type": "AbsoluteCopyNumber"
+            "relative_copy_class": "partial loss",
+            "type": "RelativeCopyNumber"
         },
         "molecule_context": "genomic",
         "structural_type": "SO:0001743"
@@ -1786,9 +1971,9 @@ def genomic_uncertain_del_y():
     params = {
         "id": "normalize.variation:NC_000024.10%3Ag.%28%3F_14076802%29_%2857165209_%3F%29del",  # noqa: E501
         "type": "VariationDescriptor",
-        "variation_id": "ga4gh:VAC.mp3CeUVnK4iCnM5Z2G4MfkwmFEQbeTjR",
+        "variation_id": "ga4gh:VRC.L0F1kbaN2aaGbLwum29WEWNwji5tit2E",
         "variation": {
-            "_id": "ga4gh:VAC.mp3CeUVnK4iCnM5Z2G4MfkwmFEQbeTjR",
+            "_id": "ga4gh:VRC.L0F1kbaN2aaGbLwum29WEWNwji5tit2E",
             "subject": {
                 "_id": "ga4gh:VSL.1xIN_RumlXTIsdTWvyJznzuzxJlwUfiD",
                 "sequence_id": "ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -1807,11 +1992,8 @@ def genomic_uncertain_del_y():
                 },
                 "type": "SequenceLocation"
             },
-            "copies": {
-                "value": 0,
-                "type": "Number"
-            },
-            "type": "AbsoluteCopyNumber"
+            "relative_copy_class": "partial loss",
+            "type": "RelativeCopyNumber"
         },
         "molecule_context": "genomic",
         "structural_type": "SO:0001743"
@@ -1834,22 +2016,41 @@ def genomic_del5():
     return params
 
 
-def genomic_del5_copy_number(params, genomic_del5_seq_loc):
-    """Create genomic del5 copy number"""
-    _id = "ga4gh:VAC.JoRr5--EbLP3qAigSfQP5Y0k67uPE6xD"
+def genomic_del5_abs_cnv(params, genomic_del5_seq_loc):
+    """Create genomic del5 absolute cnv"""
+    _id = "ga4gh:VAC.foWmgooK2J3amtQE6xSGSAnlGzzBsIjy"
     params["variation"] = {
         "type": "AbsoluteCopyNumber",
         "_id": _id,
         "subject": genomic_del5_seq_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 3}
+    }
+    params["variation_id"] = _id
+
+
+def genomic_del5_rel_cnv(params, genomic_del5_seq_loc):
+    """Create genomic del5 relative cnv"""
+    _id = "ga4gh:VRC.fxZ8m34viXiB5fjxuw2xXYItk5Xi5cve"
+    params["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del5_seq_loc,
+        "relative_copy_class": "partial loss"
     }
     params["variation_id"] = _id
 
 
 @pytest.fixture(scope="module")
-def genomic_del5_default(genomic_del5, genomic_del5_seq_loc):
-    """Create a test fixture for genomic del default and cnv."""
-    genomic_del5_copy_number(genomic_del5, genomic_del5_seq_loc)
+def genomic_del5_vrc(genomic_del5, genomic_del5_seq_loc):
+    """Create a test fixture for genomic del relative cnv."""
+    genomic_del5_rel_cnv(genomic_del5, genomic_del5_seq_loc)
+    return VariationDescriptor(**genomic_del5)
+
+
+@pytest.fixture(scope="module")
+def genomic_del5_vac(genomic_del5, genomic_del5_seq_loc):
+    """Create a test fixture for genomic del absolute cnv."""
+    genomic_del5_abs_cnv(genomic_del5, genomic_del5_seq_loc)
     return VariationDescriptor(**genomic_del5)
 
 
@@ -1968,9 +2169,16 @@ def genomic_del5_free_text():
 
 
 @pytest.fixture(scope="module")
-def genomic_del5_free_text_default(genomic_del5_free_text, genomic_del5_seq_loc):
-    """Create a test fixture for genomic del default and cnv."""
-    genomic_del5_copy_number(genomic_del5_free_text, genomic_del5_seq_loc)
+def genomic_del5_free_text_vrc(genomic_del5_free_text, genomic_del5_seq_loc):
+    """Create a test fixture for genomic del relative cnv."""
+    genomic_del5_rel_cnv(genomic_del5_free_text, genomic_del5_seq_loc)
+    return VariationDescriptor(**genomic_del5_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_del5_free_text_vac(genomic_del5_free_text, genomic_del5_seq_loc):
+    """Create a test fixture for genomic del absolute cnv."""
+    genomic_del5_abs_cnv(genomic_del5_free_text, genomic_del5_seq_loc)
     return VariationDescriptor(**genomic_del5_free_text)
 
 
@@ -2004,8 +2212,20 @@ def genomic_del6():
     return params
 
 
-def genomic_del6_copy_number(params, genomic_del6_seq_loc):
-    """Create genomic del6 copy number"""
+def genomic_del6_rel_cnv(params, genomic_del6_seq_loc):
+    """Create genomic del6 relative cnv"""
+    _id = "ga4gh:VRC.mO5A42JUswyNIbJPLuE-2fhquQEZpXxn"
+    params["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": _id,
+        "subject": genomic_del6_seq_loc,
+        "relative_copy_class": "partial loss"
+    }
+    params["variation_id"] = _id
+
+
+def genomic_del6_abs_cnv(params, genomic_del6_seq_loc):
+    """Create genomic del6 absolute cnv"""
     _id = "ga4gh:VAC.6RkHgDOiRMZKMKgI6rmG9C3T6WuMhcex"
     params["variation"] = {
         "type": "AbsoluteCopyNumber",
@@ -2017,9 +2237,16 @@ def genomic_del6_copy_number(params, genomic_del6_seq_loc):
 
 
 @pytest.fixture(scope="module")
-def genomic_del6_default(genomic_del6, genomic_del6_seq_loc):
-    """Create a test fixture for genomic del default and cnv."""
-    genomic_del6_copy_number(genomic_del6, genomic_del6_seq_loc)
+def genomic_del6_vrc(genomic_del6, genomic_del6_seq_loc):
+    """Create a test fixture for genomic del relative cnv."""
+    genomic_del6_rel_cnv(genomic_del6, genomic_del6_seq_loc)
+    return VariationDescriptor(**genomic_del6)
+
+
+@pytest.fixture(scope="module")
+def genomic_del6_vac(genomic_del6, genomic_del6_seq_loc):
+    """Create a test fixture for genomic del absolute cnv."""
+    genomic_del6_abs_cnv(genomic_del6, genomic_del6_seq_loc)
     return VariationDescriptor(**genomic_del6)
 
 
@@ -2138,9 +2365,16 @@ def genomic_del6_free_text():
 
 
 @pytest.fixture(scope="module")
-def genomic_del6_free_text_default(genomic_del6_free_text, genomic_del6_seq_loc):
-    """Create a test fixture for genomic del default and cnv."""
-    genomic_del6_copy_number(genomic_del6_free_text, genomic_del6_seq_loc)
+def genomic_del6_free_text_vrc(genomic_del6_free_text, genomic_del6_seq_loc):
+    """Create a test fixture for genomic del relative cnv."""
+    genomic_del6_rel_cnv(genomic_del6_free_text, genomic_del6_seq_loc)
+    return VariationDescriptor(**genomic_del6_free_text)
+
+
+@pytest.fixture(scope="module")
+def genomic_del6_free_text_vac(genomic_del6_free_text, genomic_del6_seq_loc):
+    """Create a test fixture for genomic del absolute cnv."""
+    genomic_del6_abs_cnv(genomic_del6_free_text, genomic_del6_seq_loc)
     return VariationDescriptor(**genomic_del6_free_text)
 
 
@@ -2169,42 +2403,42 @@ async def assert_text_variation(query_list, test_query_handler):
 
 
 @pytest.mark.asyncio
-async def test_genomic_dup1(test_query_handler, genomic_dup1_default,
-                            genomic_dup1_cnv, genomic_dup1_rse,
-                            genomic_dup1_free_text_default,
-                            genomic_dup1_free_text_cnv, genomic_dup1_free_text_rse):
+async def test_genomic_dup1(test_query_handler, genomic_dup1_lse,
+                            genomic_dup1_vac, genomic_dup1_rse,
+                            genomic_dup1_free_text_lse,
+                            genomic_dup1_free_text_vac, genomic_dup1_free_text_rse):
     """Test that genomic duplication works correctly."""
     q = "NC_000003.12:g.49531262dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup1_default, q)
+    assertion_checks(resp, genomic_dup1_lse, q)
 
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup1_default, q)
+    assertion_checks(resp, genomic_dup1_lse, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup1_cnv, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup1_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup1_rse, q)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_dup1_default, q)
+    assertion_checks(resp, genomic_dup1_lse, q)
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup1_lse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup1_lse, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup1_cnv, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup1_vac, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup1_rse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_dup1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup1_lse, q, ignore_id=True)
 
     # Free Text
     for q in [
@@ -2212,19 +2446,19 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_default,
         "DAG1 g.49531262dup"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_dup1_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup1_free_text_lse, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_dup1_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup1_free_text_lse, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_dup1_free_text_cnv, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_dup1_free_text_vac, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
         assertion_checks(resp, genomic_dup1_free_text_rse, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "literal_seq_expr")
-        assertion_checks(resp, genomic_dup1_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup1_free_text_lse, q, ignore_id=True)
 
     # Invalid
     invalid_queries = [
@@ -2236,35 +2470,35 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_dup2(test_query_handler, genomic_dup2_default, genomic_dup2_cnv,
+async def test_genomic_dup2(test_query_handler, genomic_dup2_lse, genomic_dup2_vac,
                             genomic_dup2_rse, genomic_dup2_free_text_default,
-                            genomic_dup2_free_text_cnv, genomic_dup2_free_text_rse):
+                            genomic_dup2_free_text_vac, genomic_dup2_free_text_rse):
     """Test that genomic duplication works correctly."""
     q = "NC_000016.10:g.2087938_2087948dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup2_default, q)
+    assertion_checks(resp, genomic_dup2_lse, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup2_cnv, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup2_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup2_rse, q)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_dup2_default, q)
+    assertion_checks(resp, genomic_dup2_lse, q)
 
     q = "NC_000016.9:g.2137939_2137949dup"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup2_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup2_lse, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup2_cnv, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup2_vac, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup2_rse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_dup2_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup2_lse, q, ignore_id=True)
 
     # Free text
     for q in [
@@ -2274,8 +2508,8 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_default, genomic_du
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup2_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_dup2_free_text_cnv, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_dup2_free_text_vac, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
         assertion_checks(resp, genomic_dup2_free_text_rse, q, ignore_id=True)
@@ -2293,16 +2527,17 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_default, genomic_du
 
 
 @pytest.mark.asyncio
-async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
-                            genomic_dup3_rse_lse, genomic_dup3_free_text_default,
+async def test_genomic_dup3(test_query_handler, genomic_dup3_vrc, genomic_dup3_vac,
+                            genomic_dup3_rse_lse, genomic_dup3_free_text_vac,
+                            genomic_dup3_free_text_vrc,
                             genomic_dup3_free_text_rse_lse):
     """Test that genomic duplication works correctly."""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup3_default, q)
+    assertion_checks(resp, genomic_dup3_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup3_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
+    assertion_checks(resp, genomic_dup3_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup3_rse_lse, q)
@@ -2312,10 +2547,10 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup3_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup3_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup3_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
+    assertion_checks(resp, genomic_dup3_vac, q, ignore_id=True)
 
     genomic_dup3_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2331,10 +2566,10 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
         "DMD g.(31147274_31147278)_(31182737_31182739)dup"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_dup3_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup3_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_dup3_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=3)
+        assertion_checks(resp, genomic_dup3_free_text_vac, q, ignore_id=True)
 
         genomic_dup3_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2353,16 +2588,17 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
-                            genomic_dup4_rse_lse, genomic_dup4_free_text_default,
+async def test_genomic_dup4(test_query_handler, genomic_dup4_vac, genomic_dup4_vrc,
+                            genomic_dup4_rse_lse, genomic_dup4_free_text_vac,
+                            genomic_dup4_free_text_vrc,
                             genomic_dup4_free_text_rse_lse):
     """Test that genomic duplication works correctly."""
     q = "NC_000020.11:g.(?_30417576)_(31394018_?)dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup4_default, q)
+    assertion_checks(resp, genomic_dup4_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup4_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup4_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup4_rse_lse, q)
@@ -2372,10 +2608,10 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup4_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup4_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup4_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup4_vac, q, ignore_id=True)
 
     genomic_dup4_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2390,10 +2626,10 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
         "PRPF8 g.(?_1674442)_(1684571_?)dup"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_dup4_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup4_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_dup4_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_dup4_free_text_vac, q, ignore_id=True)
 
         genomic_dup4_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2413,16 +2649,17 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
-                            genomic_dup5_rse_lse, genomic_dup5_free_text_default,
+async def test_genomic_dup5(test_query_handler, genomic_dup5_vac, genomic_dup5_vrc,
+                            genomic_dup5_rse_lse, genomic_dup5_free_text_vac,
+                            genomic_dup5_free_text_vrc,
                             genomic_dup5_free_text_rse_lse):
     """Test that genomic duplication works correctly."""
     q = "NC_000023.11:g.(?_154021812)_154092209dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup5_default, q)
+    assertion_checks(resp, genomic_dup5_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup5_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup5_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup5_rse_lse, q)
@@ -2432,10 +2669,10 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup5_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup5_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup5_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_dup5_vac, q, ignore_id=True)
 
     genomic_dup5_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2450,10 +2687,10 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
         "MECP2 g.(?_154021812)_154092209dup"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_dup5_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup5_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_dup5_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_dup5_free_text_vac, q, ignore_id=True)
 
         genomic_dup5_free_text_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2474,16 +2711,17 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
-                            genomic_dup6_rse_lse, genomic_dup6_free_text_default,
+async def test_genomic_dup6(test_query_handler, genomic_dup6_vac, genomic_dup6_vrc,
+                            genomic_dup6_rse_lse, genomic_dup6_free_text_vac,
+                            genomic_dup6_free_text_vrc,
                             genomic_dup6_free_text_rse_lse):
     """Test that genomic duplication works correctly."""
     q = "NC_000023.11:g.154021812_(154092209_?)dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup6_default, q)
+    assertion_checks(resp, genomic_dup6_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup6_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
+    assertion_checks(resp, genomic_dup6_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup6_rse_lse, q)
@@ -2493,10 +2731,10 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_dup6_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_dup6_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_dup6_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
+    assertion_checks(resp, genomic_dup6_vac, q, ignore_id=True)
 
     genomic_dup6_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2511,10 +2749,10 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
         "MECP2 g.154021812_(154092209_?)dup"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_dup6_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_dup6_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_dup6_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
+        assertion_checks(resp, genomic_dup6_free_text_vac, q, ignore_id=True)
 
         genomic_dup6_free_text_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2535,35 +2773,35 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_del1_cnv,
-                            genomic_del1_rse, genomic_del1_free_text_default,
-                            genomic_del1_free_text_cnv, genomic_del1_free_text_rse):
+async def test_genomic_del1(test_query_handler, genomic_del1_lse, genomic_del1_vac,
+                            genomic_del1_rse, genomic_del1_free_text_lse,
+                            genomic_del1_free_text_vac, genomic_del1_free_text_rse):
     """Test that genomic deletion works correctly."""
     q = "NC_000003.12:g.10149811del"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del1_default, q)
+    assertion_checks(resp, genomic_del1_lse, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del1_cnv, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del1_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del1_rse, q)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_del1_default, q)
+    assertion_checks(resp, genomic_del1_lse, q)
 
     q = "NC_000003.11:g.10191495del"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del1_lse, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del1_cnv, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del1_vac, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del1_rse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del1_lse, q, ignore_id=True)
 
     # Free text
     for q in [
@@ -2571,31 +2809,31 @@ async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_de
         "VHL g.10149811del"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_del1_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_del1_free_text_lse, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_del1_free_text_cnv, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_del1_free_text_vac, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
         assertion_checks(resp, genomic_del1_free_text_rse, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "literal_seq_expr")
-        assertion_checks(resp, genomic_del1_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_del1_free_text_lse, q, ignore_id=True)
 
     # gnomad vcf
     q = "3-10149810-CT-C"  # 38
     resp = await test_query_handler.normalize(q)
-    assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del1_lse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del1_lse, q, ignore_id=True)
 
     q = "3-10191494-CT-C"  # 37
     resp = await test_query_handler.normalize(q)
-    assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del1_lse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
-    assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del1_lse, q, ignore_id=True)
 
     # Invalid
     invalid_queries = [
@@ -2607,35 +2845,35 @@ async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_de
 
 
 @pytest.mark.asyncio
-async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_del2_cnv,
+async def test_genomic_del2(test_query_handler, genomic_del2_lse, genomic_del2_vac,
                             genomic_del2_rse, genomic_del2_free_text_default,
                             genomic_del2_free_text_cnv, genomic_del2_free_text_rse):
     """Test that genomic deletion works correctly."""
     q = "NC_000003.12:g.10146595_10146613del"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del2_default, q)
+    assertion_checks(resp, genomic_del2_lse, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del2_cnv, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del2_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del2_rse, q)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_del2_default, q)
+    assertion_checks(resp, genomic_del2_lse, q)
 
     q = "NC_000003.11:g.10188279_10188297del"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del2_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del2_lse, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del2_cnv, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del2_vac, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del2_rse, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "literal_seq_expr")
-    assertion_checks(resp, genomic_del2_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del2_lse, q, ignore_id=True)
 
     # Free text
     for q in [
@@ -2645,7 +2883,7 @@ async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_de
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del2_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
         assertion_checks(resp, genomic_del2_free_text_cnv, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2657,11 +2895,11 @@ async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_de
     # gnomad vcf
     q = "3-10146594-AATGTTGACGGACAGCCTAT-A"
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del2_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del2_lse, q, ignore_id=True)
 
     q = "3-10188278-AATGTTGACGGACAGCCTAT-A"
     resp = await test_query_handler.normalize(q)
-    assertion_checks(resp, genomic_del2_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del2_lse, q, ignore_id=True)
 
     # Invalid
     invalid_queries = [
@@ -2673,16 +2911,17 @@ async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_de
 
 
 @pytest.mark.asyncio
-async def test_genomic_del3(test_query_handler, genomic_del3_default,
-                            genomic_del3_rse_lse, genomic_del3_free_text_default,
+async def test_genomic_del3(test_query_handler, genomic_del3_vac, genomic_del3_vrc,
+                            genomic_del3_rse_lse, genomic_del3_free_text_vac,
+                            genomic_del3_free_text_vrc,
                             genomic_del3_free_text_rse_lse):
     """Test that genomic deletion works correctly."""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)del"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del3_default, q)
+    assertion_checks(resp, genomic_del3_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del3_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=3)
+    assertion_checks(resp, genomic_del3_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del3_rse_lse, q)
@@ -2692,10 +2931,10 @@ async def test_genomic_del3(test_query_handler, genomic_del3_default,
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del3_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del3_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del3_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=3)
+    assertion_checks(resp, genomic_del3_vac, q, ignore_id=True)
 
     genomic_del3_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2710,10 +2949,10 @@ async def test_genomic_del3(test_query_handler, genomic_del3_default,
         "EFNB1 g.(68839265_68839268)_(68841120_68841125)del"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_del3_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_del3_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_del3_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=3)
+        assertion_checks(resp, genomic_del3_free_text_vac, q, ignore_id=True)
 
         genomic_del3_free_text_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2733,17 +2972,17 @@ async def test_genomic_del3(test_query_handler, genomic_del3_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_del4(test_query_handler, genomic_del4_default,
+async def test_genomic_del4(test_query_handler, genomic_del4_vac, genomic_del4_vrc,
                             genomic_del4_rse_lse, genomic_uncertain_del_2,
-                            genomic_uncertain_del_y, genomic_del4_free_text_default,
-                            genomic_del4_free_text_rse_lse):
+                            genomic_uncertain_del_y, genomic_del4_free_text_vac,
+                            genomic_del4_free_text_rse_lse, genomic_del4_free_text_vrc):
     """Test that genomic deletion works correctly."""
     q = "NC_000023.11:g.(?_31120496)_(33339477_?)del"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del4_default, q)
+    assertion_checks(resp, genomic_del4_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del4_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del4_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del4_rse_lse, q)
@@ -2753,10 +2992,10 @@ async def test_genomic_del4(test_query_handler, genomic_del4_default,
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del4_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del4_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del4_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del4_vac, q, ignore_id=True)
 
     genomic_del4_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2780,10 +3019,10 @@ async def test_genomic_del4(test_query_handler, genomic_del4_default,
         "COL4A4 g.(?_227022028)_(227025830_?)del"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_del4_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_del4_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_del4_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_del4_free_text_vac, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
         assertion_checks(resp, genomic_del4_free_text_rse_lse, q, ignore_id=True)
@@ -2802,16 +3041,17 @@ async def test_genomic_del4(test_query_handler, genomic_del4_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_del5(test_query_handler, genomic_del5_default,
-                            genomic_del5_rse_lse, genomic_del5_free_text_default,
+async def test_genomic_del5(test_query_handler, genomic_del5_vac, genomic_del5_vrc,
+                            genomic_del5_rse_lse, genomic_del5_free_text_vac,
+                            genomic_del5_free_text_vrc,
                             genomic_del5_free_text_rse_lse):
     """Test that genomic deletion works correctly."""
     q = "NC_000023.11:g.(?_18575354)_18653629del"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del5_default, q)
+    assertion_checks(resp, genomic_del5_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del5_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=4)
+    assertion_checks(resp, genomic_del5_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del5_rse_lse, q)
@@ -2821,10 +3061,10 @@ async def test_genomic_del5(test_query_handler, genomic_del5_default,
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del5_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del5_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del5_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=4)
+    assertion_checks(resp, genomic_del5_vac, q, ignore_id=True)
 
     genomic_del5_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2840,10 +3080,10 @@ async def test_genomic_del5(test_query_handler, genomic_del5_default,
         "CDKL5 g.(?_18575354)_18653629del"
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_del5_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_del5_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_del5_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=4)
+        assertion_checks(resp, genomic_del5_free_text_vac, q, ignore_id=True)
 
         genomic_del5_free_text_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2864,16 +3104,17 @@ async def test_genomic_del5(test_query_handler, genomic_del5_default,
 
 
 @pytest.mark.asyncio
-async def test_genomic_del6(test_query_handler, genomic_del6_default,
-                            genomic_del6_rse_lse, genomic_del6_free_text_default,
+async def test_genomic_del6(test_query_handler, genomic_del6_vac, genomic_del6_vrc,
+                            genomic_del6_rse_lse, genomic_del6_free_text_vac,
+                            genomic_del6_free_text_vrc,
                             genomic_del6_free_text_rse_lse):
     """Test that genomic deletion works correctly."""
     q = "NC_000006.12:g.133462764_(133464858_?)del"  # 38
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del6_default, q)
+    assertion_checks(resp, genomic_del6_vrc, q)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del6_default, q)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del6_vac, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del6_rse_lse, q)
@@ -2883,10 +3124,10 @@ async def test_genomic_del6(test_query_handler, genomic_del6_default,
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
     resp = await test_query_handler.normalize(q, "default")
-    assertion_checks(resp, genomic_del6_default, q, ignore_id=True)
+    assertion_checks(resp, genomic_del6_vrc, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "absolute_cnv")
-    assertion_checks(resp, genomic_del6_default, q, ignore_id=True)
+    resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+    assertion_checks(resp, genomic_del6_vac, q, ignore_id=True)
 
     genomic_del6_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2902,10 +3143,10 @@ async def test_genomic_del6(test_query_handler, genomic_del6_default,
         "EYA4 g.133462764_(133464858_?)del"  # 38
     ]:
         resp = await test_query_handler.normalize(q, "default")
-        assertion_checks(resp, genomic_del6_free_text_default, q, ignore_id=True)
+        assertion_checks(resp, genomic_del6_free_text_vrc, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "absolute_cnv")
-        assertion_checks(resp, genomic_del6_free_text_default, q, ignore_id=True)
+        resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
+        assertion_checks(resp, genomic_del6_free_text_vac, q, ignore_id=True)
 
         genomic_del6_rse_lse.variation.definition = q
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2942,6 +3183,15 @@ async def test_parameters(test_query_handler):
     assert resp
     assert test_query_handler.normalize_handler.warnings == []
 
+    resp = await test_query_handler.normalize(q, " absolute_CnV ", baseline_copies=2)
+    assert resp
+    assert test_query_handler.normalize_handler.warnings == []
+
     resp = await test_query_handler.normalize(q, " absolute_CnV ")
+    assert not resp
+    assert test_query_handler.normalize_handler.warnings == \
+        ["absolute_cnv mode requires `baseline_copies`"]
+
+    resp = await test_query_handler.normalize(q, " relative_CnV ")
     assert resp
     assert test_query_handler.normalize_handler.warnings == []

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -245,6 +245,19 @@ def genomic_dup1_vac(genomic_dup1, genomic_dup1_38_vac):
 
 
 @pytest.fixture(scope="module")
+def genomic_dup1_vrc(genomic_dup1, genomic_dup1_seq_loc):
+    """Create a test fixture for genomic dup relative CNV."""
+    genomic_dup1["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": "ga4gh:VRC.dhn3PLeop46_QYTlYxiIW18nrTfYqJ8N",
+        "subject": genomic_dup1_seq_loc,
+        "relative_copy_class": "high-level gain"
+    }
+    genomic_dup1["variation_id"] = genomic_dup1["variation"]["_id"]
+    return VariationDescriptor(**genomic_dup1)
+
+
+@pytest.fixture(scope="module")
 def genomic_dup1_rse(genomic_dup1, genomic_dup1_seq_loc):
     """Create a test fixture for genomic dup RSE."""
     _id = "ga4gh:VA.lAyulP9JxvQReKWjpq0LbO50r2UTeMkl"
@@ -473,6 +486,19 @@ def genomic_dup2_lse(genomic_dup2, genomic_dup2_seq_loc):
 def genomic_dup2_vac(genomic_dup2, genomic_dup2_38_vac):
     """Create a test fixture for genomic dup absolute CNV."""
     genomic_dup2["variation"] = genomic_dup2_38_vac
+    genomic_dup2["variation_id"] = genomic_dup2["variation"]["_id"]
+    return VariationDescriptor(**genomic_dup2)
+
+
+@pytest.fixture(scope="module")
+def genomic_dup2_vrc(genomic_dup2, genomic_dup2_seq_loc):
+    """Create a test fixture for genomic dup relative CNV."""
+    genomic_dup2["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": "ga4gh:VRC.xuC326dmLBd33E4d-z9JItz0mt24JR-I",
+        "subject": genomic_dup2_seq_loc,
+        "relative_copy_class": "low-level gain"
+    }
     genomic_dup2["variation_id"] = genomic_dup2["variation"]["_id"]
     return VariationDescriptor(**genomic_dup2)
 
@@ -1225,6 +1251,19 @@ def genomic_del1_vac(genomic_del1, genomic_del1_38_vac):
 
 
 @pytest.fixture(scope="module")
+def genomic_del1_vrc(genomic_del1, genomic_del1_seq_loc):
+    """Create a test fixture for genomic del relative CNV."""
+    genomic_del1["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": "ga4gh:VRC.FHImCphKfSBeobf9HO6qpu_Bm5U9VfHz",
+        "subject": genomic_del1_seq_loc,
+        "relative_copy_class": "copy neutral"
+    }
+    genomic_del1["variation_id"] = genomic_del1["variation"]["_id"]
+    return VariationDescriptor(**genomic_del1)
+
+
+@pytest.fixture(scope="module")
 def genomic_del1_rse(genomic_del1, genomic_del1_seq_loc):
     """Create a test fixture for genomic del RSE."""
     _id = "ga4gh:VA.6fIEZ3R2W4wIaltUX1jyw9ap5YN6oGDT"
@@ -1375,6 +1414,19 @@ def genomic_del2_lse(genomic_del2, genomic_del2_seq_loc):
 def genomic_del2_vac(genomic_del2, genomic_del2_38_vac):
     """Create a test fixture for genomic del absolute CNV."""
     genomic_del2["variation"] = genomic_del2_38_vac
+    genomic_del2["variation_id"] = genomic_del2["variation"]["_id"]
+    return VariationDescriptor(**genomic_del2)
+
+
+@pytest.fixture(scope="module")
+def genomic_del2_vrc(genomic_del2, genomic_del2_seq_loc):
+    """Create a test fixture for genomic del relative CNV."""
+    genomic_del2["variation"] = {
+        "type": "RelativeCopyNumber",
+        "_id": "ga4gh:VRC.WtEs7KGUIjxWaV9Wx0lCCgDyyWVl-ykM",
+        "subject": genomic_del2_seq_loc,
+        "relative_copy_class": "complete loss"
+    }
     genomic_del2["variation_id"] = genomic_del2["variation"]["_id"]
     return VariationDescriptor(**genomic_del2)
 
@@ -2404,7 +2456,7 @@ async def assert_text_variation(query_list, test_query_handler):
 
 @pytest.mark.asyncio
 async def test_genomic_dup1(test_query_handler, genomic_dup1_lse,
-                            genomic_dup1_vac, genomic_dup1_rse,
+                            genomic_dup1_vac, genomic_dup1_vrc, genomic_dup1_rse,
                             genomic_dup1_free_text_lse,
                             genomic_dup1_free_text_vac, genomic_dup1_free_text_rse):
     """Test that genomic duplication works correctly."""
@@ -2417,6 +2469,10 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_lse,
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup1_vac, q)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="high-level gain")
+    assertion_checks(resp, genomic_dup1_vrc, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup1_rse, q)
@@ -2433,6 +2489,10 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_lse,
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup1_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="high-level gain")
+    assertion_checks(resp, genomic_dup1_vrc, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup1_rse, q, ignore_id=True)
@@ -2471,8 +2531,9 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_lse,
 
 @pytest.mark.asyncio
 async def test_genomic_dup2(test_query_handler, genomic_dup2_lse, genomic_dup2_vac,
-                            genomic_dup2_rse, genomic_dup2_free_text_default,
-                            genomic_dup2_free_text_vac, genomic_dup2_free_text_rse):
+                            genomic_dup2_vrc, genomic_dup2_rse,
+                            genomic_dup2_free_text_default, genomic_dup2_free_text_vac,
+                            genomic_dup2_free_text_rse):
     """Test that genomic duplication works correctly."""
     q = "NC_000016.10:g.2087938_2087948dup"  # 38
     resp = await test_query_handler.normalize(q, "default")
@@ -2480,6 +2541,9 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_lse, genomic_dup2_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup2_vac, q)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup2_vrc, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup2_rse, q)
@@ -2493,6 +2557,9 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_lse, genomic_dup2_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup2_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup2_vrc, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup2_rse, q, ignore_id=True)
@@ -2539,6 +2606,10 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_vrc, genomic_dup3_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
     assertion_checks(resp, genomic_dup3_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="low-level gain")
+    assertion_checks(resp, genomic_dup3_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup3_rse_lse, q)
 
@@ -2551,6 +2622,9 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_vrc, genomic_dup3_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
     assertion_checks(resp, genomic_dup3_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup3_vrc, q, ignore_id=True)
 
     genomic_dup3_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2600,6 +2674,9 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_vac, genomic_dup4_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup4_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup4_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup4_rse_lse, q)
 
@@ -2612,6 +2689,9 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_vac, genomic_dup4_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup4_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup4_vrc, q, ignore_id=True)
 
     genomic_dup4_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2661,6 +2741,9 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_vac, genomic_dup5_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup5_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup5_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup5_rse_lse, q)
 
@@ -2673,6 +2756,9 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_vac, genomic_dup5_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_dup5_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup5_vrc, q, ignore_id=True)
 
     genomic_dup5_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2723,6 +2809,9 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_vac, genomic_dup6_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
     assertion_checks(resp, genomic_dup6_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup6_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_dup6_rse_lse, q)
 
@@ -2735,6 +2824,9 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_vac, genomic_dup6_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=1)
     assertion_checks(resp, genomic_dup6_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_dup6_vrc, q, ignore_id=True)
 
     genomic_dup6_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2774,8 +2866,9 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_vac, genomic_dup6_v
 
 @pytest.mark.asyncio
 async def test_genomic_del1(test_query_handler, genomic_del1_lse, genomic_del1_vac,
-                            genomic_del1_rse, genomic_del1_free_text_lse,
-                            genomic_del1_free_text_vac, genomic_del1_free_text_rse):
+                            genomic_del1_vrc, genomic_del1_rse,
+                            genomic_del1_free_text_lse, genomic_del1_free_text_vac,
+                            genomic_del1_free_text_rse):
     """Test that genomic deletion works correctly."""
     q = "NC_000003.12:g.10149811del"  # 38
     resp = await test_query_handler.normalize(q, "default")
@@ -2783,6 +2876,10 @@ async def test_genomic_del1(test_query_handler, genomic_del1_lse, genomic_del1_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del1_vac, q)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="copy neutral")
+    assertion_checks(resp, genomic_del1_vrc, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del1_rse, q)
@@ -2796,6 +2893,10 @@ async def test_genomic_del1(test_query_handler, genomic_del1_lse, genomic_del1_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del1_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="copy neutral")
+    assertion_checks(resp, genomic_del1_vrc, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del1_rse, q, ignore_id=True)
@@ -2846,8 +2947,9 @@ async def test_genomic_del1(test_query_handler, genomic_del1_lse, genomic_del1_v
 
 @pytest.mark.asyncio
 async def test_genomic_del2(test_query_handler, genomic_del2_lse, genomic_del2_vac,
-                            genomic_del2_rse, genomic_del2_free_text_default,
-                            genomic_del2_free_text_cnv, genomic_del2_free_text_rse):
+                            genomic_del2_vrc, genomic_del2_rse,
+                            genomic_del2_free_text_default, genomic_del2_free_text_cnv,
+                            genomic_del2_free_text_rse):
     """Test that genomic deletion works correctly."""
     q = "NC_000003.12:g.10146595_10146613del"  # 38
     resp = await test_query_handler.normalize(q, "default")
@@ -2855,6 +2957,10 @@ async def test_genomic_del2(test_query_handler, genomic_del2_lse, genomic_del2_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del2_vac, q)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="complete loss")
+    assertion_checks(resp, genomic_del2_vrc, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del2_rse, q)
@@ -2868,6 +2974,10 @@ async def test_genomic_del2(test_query_handler, genomic_del2_lse, genomic_del2_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del2_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv",
+                                              relative_copy_class="complete loss")
+    assertion_checks(resp, genomic_del2_vrc, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del2_rse, q, ignore_id=True)
@@ -2923,6 +3033,9 @@ async def test_genomic_del3(test_query_handler, genomic_del3_vac, genomic_del3_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=3)
     assertion_checks(resp, genomic_del3_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del3_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del3_rse_lse, q)
 
@@ -2935,6 +3048,9 @@ async def test_genomic_del3(test_query_handler, genomic_del3_vac, genomic_del3_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=3)
     assertion_checks(resp, genomic_del3_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del3_vrc, q, ignore_id=True)
 
     genomic_del3_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2984,6 +3100,9 @@ async def test_genomic_del4(test_query_handler, genomic_del4_vac, genomic_del4_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del4_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del4_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del4_rse_lse, q)
 
@@ -2996,6 +3115,9 @@ async def test_genomic_del4(test_query_handler, genomic_del4_vac, genomic_del4_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del4_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del4_vrc, q, ignore_id=True)
 
     genomic_del4_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -3053,6 +3175,9 @@ async def test_genomic_del5(test_query_handler, genomic_del5_vac, genomic_del5_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=4)
     assertion_checks(resp, genomic_del5_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del5_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del5_rse_lse, q)
 
@@ -3065,6 +3190,9 @@ async def test_genomic_del5(test_query_handler, genomic_del5_vac, genomic_del5_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=4)
     assertion_checks(resp, genomic_del5_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del5_vrc, q, ignore_id=True)
 
     genomic_del5_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -3116,6 +3244,9 @@ async def test_genomic_del6(test_query_handler, genomic_del6_vac, genomic_del6_v
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del6_vac, q)
 
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del6_vrc, q)
+
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
     assertion_checks(resp, genomic_del6_rse_lse, q)
 
@@ -3128,6 +3259,9 @@ async def test_genomic_del6(test_query_handler, genomic_del6_vac, genomic_del6_v
 
     resp = await test_query_handler.normalize(q, "absolute_cnv", baseline_copies=2)
     assertion_checks(resp, genomic_del6_vac, q, ignore_id=True)
+
+    resp = await test_query_handler.normalize(q, "relative_cnv")
+    assertion_checks(resp, genomic_del6_vrc, q, ignore_id=True)
 
     genomic_del6_rse_lse.variation.definition = q
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -2181,7 +2181,7 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup1_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup1_cnv, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2197,7 +2197,7 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup1_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup1_cnv, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2217,7 +2217,7 @@ async def test_genomic_dup1(test_query_handler, genomic_dup1_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup1_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_dup1_free_text_cnv, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2244,7 +2244,7 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_default, genomic_du
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup2_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup2_cnv, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2257,7 +2257,7 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_default, genomic_du
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup2_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup2_cnv, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2274,7 +2274,7 @@ async def test_genomic_dup2(test_query_handler, genomic_dup2_default, genomic_du
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup2_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_dup2_free_text_cnv, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2301,7 +2301,7 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup3_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup3_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2314,7 +2314,7 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup3_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup3_default, q, ignore_id=True)
 
     genomic_dup3_rse_lse.variation.definition = q
@@ -2333,7 +2333,7 @@ async def test_genomic_dup3(test_query_handler, genomic_dup3_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup3_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_dup3_free_text_default, q, ignore_id=True)
 
         genomic_dup3_rse_lse.variation.definition = q
@@ -2361,7 +2361,7 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup4_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup4_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2374,7 +2374,7 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup4_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup4_default, q, ignore_id=True)
 
     genomic_dup4_rse_lse.variation.definition = q
@@ -2392,7 +2392,7 @@ async def test_genomic_dup4(test_query_handler, genomic_dup4_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup4_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_dup4_free_text_default, q, ignore_id=True)
 
         genomic_dup4_rse_lse.variation.definition = q
@@ -2421,7 +2421,7 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup5_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup5_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2434,7 +2434,7 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup5_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup5_default, q, ignore_id=True)
 
     genomic_dup5_rse_lse.variation.definition = q
@@ -2452,7 +2452,7 @@ async def test_genomic_dup5(test_query_handler, genomic_dup5_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup5_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_dup5_free_text_default, q, ignore_id=True)
 
         genomic_dup5_free_text_rse_lse.variation.definition = q
@@ -2482,7 +2482,7 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup6_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup6_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2495,7 +2495,7 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_dup6_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_dup6_default, q, ignore_id=True)
 
     genomic_dup6_rse_lse.variation.definition = q
@@ -2513,7 +2513,7 @@ async def test_genomic_dup6(test_query_handler, genomic_dup6_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_dup6_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_dup6_free_text_default, q, ignore_id=True)
 
         genomic_dup6_free_text_rse_lse.variation.definition = q
@@ -2543,7 +2543,7 @@ async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_de
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del1_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del1_cnv, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2556,7 +2556,7 @@ async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_de
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del1_cnv, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2573,7 +2573,7 @@ async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_de
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del1_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_del1_free_text_cnv, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2587,7 +2587,7 @@ async def test_genomic_del1(test_query_handler, genomic_del1_default, genomic_de
     resp = await test_query_handler.normalize(q)
     assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del1_default, q, ignore_id=True)
 
     q = "3-10191494-CT-C"  # 37
@@ -2615,7 +2615,7 @@ async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_de
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del2_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del2_cnv, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2628,7 +2628,7 @@ async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_de
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del2_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del2_cnv, q, ignore_id=True)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2645,7 +2645,7 @@ async def test_genomic_del2(test_query_handler, genomic_del2_default, genomic_de
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del2_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_del2_free_text_cnv, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2681,7 +2681,7 @@ async def test_genomic_del3(test_query_handler, genomic_del3_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del3_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del3_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2694,7 +2694,7 @@ async def test_genomic_del3(test_query_handler, genomic_del3_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del3_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del3_default, q, ignore_id=True)
 
     genomic_del3_rse_lse.variation.definition = q
@@ -2712,7 +2712,7 @@ async def test_genomic_del3(test_query_handler, genomic_del3_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del3_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_del3_free_text_default, q, ignore_id=True)
 
         genomic_del3_free_text_rse_lse.variation.definition = q
@@ -2742,7 +2742,7 @@ async def test_genomic_del4(test_query_handler, genomic_del4_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del4_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del4_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2755,7 +2755,7 @@ async def test_genomic_del4(test_query_handler, genomic_del4_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del4_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del4_default, q, ignore_id=True)
 
     genomic_del4_rse_lse.variation.definition = q
@@ -2782,7 +2782,7 @@ async def test_genomic_del4(test_query_handler, genomic_del4_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del4_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_del4_free_text_default, q, ignore_id=True)
 
         resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2810,7 +2810,7 @@ async def test_genomic_del5(test_query_handler, genomic_del5_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del5_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del5_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2823,7 +2823,7 @@ async def test_genomic_del5(test_query_handler, genomic_del5_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del5_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del5_default, q, ignore_id=True)
 
     genomic_del5_rse_lse.variation.definition = q
@@ -2842,7 +2842,7 @@ async def test_genomic_del5(test_query_handler, genomic_del5_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del5_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_del5_free_text_default, q, ignore_id=True)
 
         genomic_del5_free_text_rse_lse.variation.definition = q
@@ -2872,7 +2872,7 @@ async def test_genomic_del6(test_query_handler, genomic_del6_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del6_default, q)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del6_default, q)
 
     resp = await test_query_handler.normalize(q, "repeated_seq_expr")
@@ -2885,7 +2885,7 @@ async def test_genomic_del6(test_query_handler, genomic_del6_default,
     resp = await test_query_handler.normalize(q, "default")
     assertion_checks(resp, genomic_del6_default, q, ignore_id=True)
 
-    resp = await test_query_handler.normalize(q, "cnv")
+    resp = await test_query_handler.normalize(q, "absolute_cnv")
     assertion_checks(resp, genomic_del6_default, q, ignore_id=True)
 
     genomic_del6_rse_lse.variation.definition = q
@@ -2904,7 +2904,7 @@ async def test_genomic_del6(test_query_handler, genomic_del6_default,
         resp = await test_query_handler.normalize(q, "default")
         assertion_checks(resp, genomic_del6_free_text_default, q, ignore_id=True)
 
-        resp = await test_query_handler.normalize(q, "cnv")
+        resp = await test_query_handler.normalize(q, "absolute_cnv")
         assertion_checks(resp, genomic_del6_free_text_default, q, ignore_id=True)
 
         genomic_del6_rse_lse.variation.definition = q
@@ -2942,6 +2942,6 @@ async def test_parameters(test_query_handler):
     assert resp
     assert test_query_handler.normalize_handler.warnings == []
 
-    resp = await test_query_handler.normalize(q, " CnV ")
+    resp = await test_query_handler.normalize(q, " absolute_CnV ")
     assert resp
     assert test_query_handler.normalize_handler.warnings == []

--- a/tests/test_hgvs_to_copy_number.py
+++ b/tests/test_hgvs_to_copy_number.py
@@ -105,9 +105,9 @@ def genomic_dup3_abs_38(genomic_del3_dup3_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.dvalAo00K9zGaI4lbxATjGTuNImbAefX",
+        "_id": "ga4gh:VAC.cQATJ6a1uGwXOHu-advv8lRsMgjNLKul",
         "subject": genomic_del3_dup3_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -150,9 +150,9 @@ def genomic_dup3_abs_37(genomic_dup3_37_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.A0wc5mTclTJP_z-lMhuZ-pHeVWI_vq7L",
+        "_id": "ga4gh:VAC.Pv9I4Dqk69w-tX0axaikVqid-pozxU74",
         "subject": genomic_dup3_37_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -235,23 +235,23 @@ def genomic_dup4_rel_37(genomic_dup4_37_loc):
 
 
 @pytest.fixture(scope="module")
-def genomic_dup5_abs_38(genoimc_dup5_loc):
+def genomic_dup5_abs_38(genomic_dup5_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.UwgjCJsg8XKPX8e2zhtw3jFfeUfgrGAZ",
-        "subject": genoimc_dup5_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "_id": "ga4gh:VAC.BUEI9XPTvjBvNUoREsXRsm8THNuR5Fe7",
+        "subject": genomic_dup5_loc,
+        "copies": {"type": "Number", "value": 4}
     }
 
 
 @pytest.fixture(scope="module")
-def genomic_dup5_rel_38(genoimc_dup5_loc):
+def genomic_dup5_rel_38(genomic_dup5_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
         "_id": "ga4gh:VRC.vy8SSVFuaeZTkUCCv6izNCkF0zgbBG7G",
-        "subject": genoimc_dup5_loc,
+        "subject": genomic_dup5_loc,
         "relative_copy_class": "partial loss"
     }
 
@@ -283,9 +283,9 @@ def genomic_dup5_abs_37(genomic_dup5_37_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.tDxzJ8fPRjdALG4NS4TYvooyrzY6f1ok",
+        "_id": "ga4gh:VAC.1-pcrgINIDzVXrTgs7xshzBQVlhQ_dX8",
         "subject": genomic_dup5_37_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 4}
     }
 
 
@@ -305,9 +305,9 @@ def genomic_dup6_abs_38(genoimc_dup6_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.vtHdiIdXvKO4z4M5x_26UoMN4HVW_Kh2",
+        "_id": "ga4gh:VAC.ZkgR6TD7VypzVrLAYFnSb-D7DXp62Yfn",
         "subject": genoimc_dup6_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -349,9 +349,9 @@ def genomic_dup6_abs_37(genomic_dup6_37_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.iffkBKjSE6eslcD6noq7mg1Mzao2f1dg",
+        "_id": "ga4gh:VAC.8u4HiQWnHhwGZtIBF_DEYQCNdaFKOHuN",
         "subject": genomic_dup6_37_loc,
-        "copies": {"type": "DefiniteRange", "min": 2, "max": 3}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -467,9 +467,9 @@ def genomic_del3_abs_38(genomic_del3_dup3_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.0ZYzw7KuXYv7a_TV3eF5qjRbqN0HvxBx",
+        "_id": "ga4gh:VAC.cQATJ6a1uGwXOHu-advv8lRsMgjNLKul",
         "subject": genomic_del3_dup3_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -512,9 +512,9 @@ def genomic_del3_abs_37(genomic_del3_37_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.IUXYnlP4vLf6YAVxDaZU6sxVoS27ueAj",
+        "_id": "ga4gh:VAC.Pv9I4Dqk69w-tX0axaikVqid-pozxU74",
         "subject": genomic_del3_37_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -534,9 +534,9 @@ def genomic_del4_abs_38(genomic_del4_seq_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.Dyccf3xmoPSN90ksXP2KAb5TuFIkgO6r",
+        "_id": "ga4gh:VAC.XCyM9ayMTrarSAMc00sHCmsPcCV8ymIN",
         "subject": genomic_del4_seq_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 4}
     }
 
 
@@ -579,9 +579,9 @@ def genomic_del4_abs_37(genomic_del4_37_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.myd_sAvC5-hsNwJ9DmmdumdyJa-kj7_o",
+        "_id": "ga4gh:VAC.gXM6rRlCid3C1DmUGT2XynmGXDvt80P6",
         "subject": genomic_del4_37_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 4}
     }
 
 
@@ -601,9 +601,9 @@ def genomic_del5_abs_38(genomic_del5_seq_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.JoRr5--EbLP3qAigSfQP5Y0k67uPE6xD",
+        "_id": "ga4gh:VAC.9A8BspUwfxSsceIScGOBtivMMASDsaid",
         "subject": genomic_del5_seq_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -645,9 +645,9 @@ def genomic_del5_abs_37(genomic_del5_37_loc):
     """Create test fixture absolute copy number variation"""
     return {
         "type": "AbsoluteCopyNumber",
-        "_id": "ga4gh:VAC.st1tPzrcySJCPvxlV63ZSYXhohXH_rf0",
+        "_id": "ga4gh:VAC.9zhlg8DRSsE87N5SngYrMDWXStzp_WOX",
         "subject": genomic_del5_37_loc,
-        "copies": {"type": "DefiniteRange", "min": 0, "max": 1}
+        "copies": {"type": "Number", "value": 2}
     }
 
 
@@ -734,16 +734,16 @@ async def test_genomic_dup1_absolute_cnv(test_query_handler, genomic_dup1_38_vac
     """Test that genomic duplication works correctly"""
     q = "NC_000003.12:g.49531262dup"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False, )
     assert resp.dict(by_alias=True) == genomic_dup1_38_vac
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup1_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=2, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_dup1_38_vac
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -779,16 +779,16 @@ async def test_genomic_dup2_absolute_cnv(test_query_handler, genomic_dup2_38_vac
     """Test that genomic duplication works correctly"""
     q = "NC_000016.10:g.2087938_2087948dup"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup2_38_vac
 
     q = "NC_000016.9:g.2137939_2137949dup"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup2_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=2, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_dup2_38_vac
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -824,16 +824,16 @@ async def test_genomic_dup3_absolute_cnv(test_query_handler, genomic_dup3_abs_38
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=1, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup3_abs_38
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=1, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup3_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=1, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_dup3_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -869,16 +869,16 @@ async def test_genomic_dup4_absolute_cnv(test_query_handler, genomic_dup4_abs_38
     """Test that genomic duplication works correctly"""
     q = "NC_000020.11:g.(?_30417576)_(31394018_?)dup"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup4_abs_38
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup4_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=2, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_dup4_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -914,16 +914,16 @@ async def test_genomic_dup5_absolute_cnv(test_query_handler, genomic_dup5_abs_38
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(?_154021812)_154092209dup"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=3, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup5_abs_38
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=3, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup5_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=3, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_dup5_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -959,16 +959,16 @@ async def test_genomic_dup6_absolute_cnv(test_query_handler, genomic_dup6_abs_38
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.154021812_(154092209_?)dup"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=1, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup6_abs_38
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=1, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_dup6_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=1, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_dup6_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -1004,16 +1004,16 @@ async def test_genomic_del1_absolute_cnv(test_query_handler, genomic_del1_38_vac
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10149811del"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del1_38_vac
 
     q = "NC_000003.11:g.10191495del"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del1_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=2, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_del1_38_vac
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -1049,16 +1049,16 @@ async def test_genomic_del2_absolute_cnv(test_query_handler, genomic_del2_38_vac
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10146595_10146613del"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del2_38_vac
 
     q = "NC_000003.11:g.10188279_10188297del"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del2_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=2, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_del2_38_vac
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -1094,16 +1094,16 @@ async def test_genomic_del3_absolute_cnv(test_query_handler, genomic_del3_abs_38
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)del"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=3, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del3_abs_38
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=3, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del3_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=3, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_del3_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -1139,16 +1139,16 @@ async def test_genomic_del4_absolute_cnv(test_query_handler, genomic_del4_abs_38
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_31120496)_(33339477_?)del"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=5, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del4_abs_38
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=5, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del4_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=5, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_del4_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -1184,16 +1184,16 @@ async def test_genomic_del5_absolute_cnv(test_query_handler, genomic_del5_abs_38
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_18575354)_18653629del"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=3, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del5_abs_38
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=3, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del5_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=3, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_del5_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
@@ -1229,16 +1229,16 @@ async def test_genomic_del6_absolute_cnv(test_query_handler, genomic_del6_abs_38
     """Test that genomic deletion works correctly"""
     q = "NC_000006.12:g.133462764_(133464858_?)del"  # 38
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del6_abs_38
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=False)
+        q, baseline_copies=2, do_liftover=False)
     assert resp.dict(by_alias=True) == genomic_del6_abs_37
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(
-        q, baseline_copies=None, do_liftover=True)
+        q, baseline_copies=2, do_liftover=True)
     assert resp.dict(by_alias=True) == genomic_del6_abs_38
 
     resp, _ = await test_query_handler.hgvs_to_absolute_copy_number(

--- a/tests/test_to_canonical_variation.py
+++ b/tests/test_to_canonical_variation.py
@@ -4,9 +4,33 @@ import copy
 import pytest
 from ga4gh.vrsatile.pydantic.vrsatile_models import CanonicalVariation
 
+from variation.schemas.normalize_response_schema import HGVSDupDelMode \
+    as HGVSDupDelModeEnum
+
 
 @pytest.fixture(scope="module")
-def variation1():
+def variation1_seq_loc():
+    """Create test fixture for variation1 sequence location"""
+    return {
+        "_id": "ga4gh:VSL.p4e9kMEY9PrKZ1BbNRuFr6n30DkwXWlX",
+        "type": "SequenceLocation",
+        "sequence_id": "ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+        "interval": {
+            "type": "SequenceInterval",
+            "start": {
+                "type": "Number",
+                "value": 20189346
+            },
+            "end": {
+                "type": "Number",
+                "value": 20189349
+            }
+        }
+    }
+
+
+@pytest.fixture(scope="module")
+def variation1_lse(variation1_seq_loc):
     """Create test fixture for NC_000013.11:20189346:GGG:GG"""
     params = {
         "_id": "ga4gh:VCC.6FxWtQdkEyVSMIOnvRj0bOEgvHgN3pRh",
@@ -15,25 +39,72 @@ def variation1():
         "variation": {
             "_id": "ga4gh:VA.KGopzor-bEw8Ot5sAQQ5o5SVx4o7TuLN",
             "type": "Allele",
-            "location": {
-                "_id": "ga4gh:VSL.p4e9kMEY9PrKZ1BbNRuFr6n30DkwXWlX",
-                "type": "SequenceLocation",
-                "sequence_id": "ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-                "interval": {
-                    "type": "SequenceInterval",
-                    "start": {
-                        "type": "Number",
-                        "value": 20189346
-                    },
-                    "end": {
-                        "type": "Number",
-                        "value": 20189349
-                    }
-                }
-            },
+            "location": variation1_seq_loc,
             "state": {
                 "type": "LiteralSequenceExpression",
                 "sequence": "GG"
+            }
+        }
+    }
+    return CanonicalVariation(**params)
+
+
+@pytest.fixture(scope="module")
+def variation1_abs_cnv(variation1_seq_loc):
+    """Create test fixture for variation1 represented as absolute cnv"""
+    params = {
+        "_id": "ga4gh:VCC.SRZiwHEKF9qJ5hCd1hKPDpjBpK29PO_4",
+        "complement": False,
+        "type": "CanonicalVariation",
+        "variation": {
+            "_id": "ga4gh:VAC.WkHL0pE5vn2yZfTlB4vo6Qr9gvFgnm2s",
+            "type": "AbsoluteCopyNumber",
+            "subject": variation1_seq_loc,
+            "copies": {"type": "Number", "value": 2}
+        }
+    }
+    return CanonicalVariation(**params)
+
+
+@pytest.fixture(scope="module")
+def variation1_rel_cnv(variation1_seq_loc):
+    """Create test fixture for variation1 represented as relative cnv"""
+    params = {
+        "_id": "ga4gh:VCC.hpdklR_18hDE3YwHTYYFJmbQd__pwBeH",
+        "complement": False,
+        "type": "CanonicalVariation",
+        "variation": {
+            "_id": "ga4gh:VRC.d0tA1C6eSo-rkg1wVQ76Bh8XLSwz36se",
+            "type": "RelativeCopyNumber",
+            "subject": variation1_seq_loc,
+            "relative_copy_class": "complete loss"
+        }
+    }
+    return CanonicalVariation(**params)
+
+
+@pytest.fixture(scope="module")
+def variation1_rse(variation1_seq_loc):
+    """Create test fixture for variation1 represented as RSE"""
+    params = {
+        "_id": "ga4gh:VCC.8bwdX-_oSSoT36vvA2Z6CVG_Mfw-jqEO",
+        "complement": False,
+        "type": "CanonicalVariation",
+        "variation": {
+            "_id": "ga4gh:VA.0TP_vHDqgjDm2Wme2U6f6upSlYxAqw4l",
+            "type": "Allele",
+            "location": variation1_seq_loc,
+            "state": {
+                "type": "RepeatedSequenceExpression",
+                "seq_expr": {
+                    "type": "DerivedSequenceExpression",
+                    "location": variation1_seq_loc,
+                    "reverse_complement": False
+                },
+                "count": {
+                    "type": "Number",
+                    "value": 0
+                }
             }
         }
     }
@@ -53,13 +124,75 @@ def variation2(braf_v600e_genomic_sub):
 
 
 @pytest.fixture(scope="module")
-def variation3(grch38_genomic_insertion_variation):
+def variation3_lse(grch38_genomic_insertion_variation):
     """Create test fixture for NC_000017.10:g.37880993_37880994insGCTTACGTGATG"""
     params = {
         "_id": "ga4gh:VCC.Wvq61Rejsn80kUCJkqSXKzCSnRwaRZNm",
         "complement": False,
         "type": "CanonicalVariation",
         "variation": grch38_genomic_insertion_variation
+    }
+    return CanonicalVariation(**params)
+
+
+@pytest.fixture(scope="module")
+def variation3_abs_cnv(grch38_genomic_insertion_seq_loc):
+    """Create test fixture for variation3 represented as absolute cnv"""
+    params = {
+        "_id": "ga4gh:VCC.DSncpwIaoyP94KOVf_45gcQGJ0_f41Pa",
+        "complement": False,
+        "type": "CanonicalVariation",
+        "variation": {
+            "_id": "ga4gh:VAC.c1xp6z9seT4j8Ae4e0gePB7LiPzjykmO",
+            "type": "AbsoluteCopyNumber",
+            "subject": grch38_genomic_insertion_seq_loc,
+            "copies": {"type": "Number", "value": 2}
+        }
+    }
+    return CanonicalVariation(**params)
+
+
+@pytest.fixture(scope="module")
+def variation3_rel_cnv(grch38_genomic_insertion_seq_loc):
+    """Create test fixture for variation3 represented as relative cnv"""
+    params = {
+        "_id": "ga4gh:VCC.fUeN_b2i0iBgad1rizfs1fXOnrZvptc9",
+        "complement": False,
+        "type": "CanonicalVariation",
+        "variation": {
+            "_id": "ga4gh:VRC.TJSKDRpI2hW8JbqGsc9yag6KrP1YVhwU",
+            "type": "RelativeCopyNumber",
+            "subject": grch38_genomic_insertion_seq_loc,
+            "relative_copy_class": "high-level gain"
+        }
+    }
+    return CanonicalVariation(**params)
+
+
+@pytest.fixture(scope="module")
+def variation3_rse(grch38_genomic_insertion_seq_loc):
+    """Create test fixture for variation3 represented as RSE"""
+    params = {
+        "_id": "ga4gh:VCC.2Dr1zKcf6_tmFlcQG_1ZgzjFsUMuSVf3",
+        "complement": False,
+        "type": "CanonicalVariation",
+        "variation": {
+            "_id": "ga4gh:VA.Psy669nQn5V84LRrECrl4DKLt4V64_5h",
+            "type": "Allele",
+            "location": grch38_genomic_insertion_seq_loc,
+            "state": {
+                "type": "RepeatedSequenceExpression",
+                "seq_expr": {
+                    "type": "DerivedSequenceExpression",
+                    "location": grch38_genomic_insertion_seq_loc,
+                    "reverse_complement": False
+                },
+                "count": {
+                    "type": "Number",
+                    "value": 2
+                }
+            }
+        }
     }
     return CanonicalVariation(**params)
 
@@ -91,29 +224,60 @@ def variation4():
 
 
 @pytest.mark.asyncio
-async def test_to_canonical_variation_deletion(test_query_handler, variation1):
+async def test_to_canonical_variation_deletion(
+    test_query_handler, variation1_lse, variation1_abs_cnv, variation1_rel_cnv,
+    variation1_rse
+):
     """Test that to_canonical_variation works correctly for deletions"""
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/17014/?new_evidence=true
     q = " NC_000013.11:20189346:GGG:GG "  # 38
     resp, w = await test_query_handler.to_canonical_variation(q, fmt="spdi")
-    assert resp == variation1
+    assert resp == variation1_lse
     assert w == []
 
     q = " NC_000013.10:20763485:GGG:GG "  # 37
     resp, w = await test_query_handler.to_canonical_variation(
         q, fmt="spdi", do_liftover=True)
-    assert resp == variation1
+    assert resp == variation1_lse
     assert w == []
 
     q = " NC_000013.11:g.20189349del "  # 38
     resp, w = await test_query_handler.to_canonical_variation(q, fmt="hgvs")
-    assert resp == variation1
+    assert resp == variation1_lse
     assert w == []
 
     q = " NC_000013.10:g.20763488del "  # 37
     resp, w = await test_query_handler.to_canonical_variation(
         q, fmt="hgvs", do_liftover=True)
-    assert resp == variation1
+    assert resp == variation1_lse
+    assert w == []
+
+    # Testing hgvs dup del mode params
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="default")
+    assert resp == variation1_lse
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="absolute_cnv",
+        baseline_copies=3)
+    assert resp == variation1_abs_cnv
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="relative_cnv",
+        relative_copy_class="complete loss")
+    assert resp == variation1_rel_cnv
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="repeated_seq_expr")
+    assert resp == variation1_rse
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="literal_seq_expr")
+    assert resp == variation1_lse
     assert w == []
 
 
@@ -161,37 +325,76 @@ async def test_to_canonical_variation_substitution(test_query_handler, variation
     assert resp == cpy_variation2
     assert w == []
 
+    # HGVS Dup Del Mode should not affect
+    for mode in [m.value for m in HGVSDupDelModeEnum.__members__.values()]:
+        resp, w = await test_query_handler.to_canonical_variation(
+            q, fmt="hgvs", complement=True, hgvs_dup_del_mode=mode,
+            baseline_copies=2)
+        assert resp == variation2
+        assert w == []
+
 
 @pytest.mark.asyncio
-async def test_to_canonical_variation_duplication(test_query_handler, variation3):
+async def test_to_canonical_variation_duplication(
+    test_query_handler, variation3_lse, variation3_abs_cnv, variation3_rel_cnv,
+    variation3_rse
+):
     """Test that to_canonical_variation works correctly for duplications"""
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/44985/
     q = "NC_000017.10:g.37880993_37880994insGCTTACGTGATG"  # 37
     resp, w = await test_query_handler.to_canonical_variation(
         q, fmt="hgvs", do_liftover=True)
-    assert resp == variation3
+    assert resp == variation3_lse
     assert w == []
 
     q = "NC_000017.11:g.39724740_39724741insGCTTACGTGATG"  # 38
     resp, w = await test_query_handler.to_canonical_variation(
         q, fmt="hgvs", do_liftover=True)  # even tho it's set it wont liftover
-    assert resp == variation3
+    assert resp == variation3_lse
     assert w == []
 
     q = "NC_000017.11:39724731:TACGTGATGGCT:TACGTGATGGCTTACGTGATGGCT"  # 38
     resp, w = await test_query_handler.to_canonical_variation(q, fmt="spdi")
-    assert resp == variation3
+    assert resp == variation3_lse
     assert w == []
 
     q = "NC_000017.11:g.39724732_39724743dup"  # 38
     resp, w = await test_query_handler.to_canonical_variation(q, fmt="hgvs")
-    assert resp == variation3
+    assert resp == variation3_lse
     assert w == []
 
     q = "NC_000017.10:g.37880985_37880996dup"  # 37
     resp, w = await test_query_handler.to_canonical_variation(
         q, fmt="hgvs", do_liftover=True)
-    assert resp == variation3
+    assert resp == variation3_lse
+    assert w == []
+
+    # Testing hgvs dup del mode params
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="default")
+    assert resp == variation3_lse
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="absolute_cnv",
+        baseline_copies=1)
+    assert resp == variation3_abs_cnv
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="relative_cnv",
+        relative_copy_class="high-level gain")
+    assert resp == variation3_rel_cnv
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="repeated_seq_expr")
+    assert resp == variation3_rse
+    assert w == []
+
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="literal_seq_expr")
+    assert resp == variation3_lse
     assert w == []
 
 
@@ -205,10 +408,17 @@ async def test_to_canonical_variation_insertions(test_query_handler, variation4)
     assert resp == variation4
     assert w == []
 
-    q = "NC_000001.11:g.2229202_2229203insCTC"  # 37
+    q = "NC_000001.11:g.2229202_2229203insCTC"  # 38
     resp, w = await test_query_handler.to_canonical_variation(q, fmt="hgvs")
     assert resp == variation4
     assert w == []
+
+    # HGVS Dup Del Mode should not affect
+    for mode in [m.value for m in HGVSDupDelModeEnum.__members__.values()]:
+        resp, w = await test_query_handler.to_canonical_variation(
+            q, fmt="hgvs", hgvs_dup_del_mode=mode, baseline_copies=2)
+        assert resp == variation4
+        assert w == []
 
     q = "NC_000001.10:2160640:C:CCTC"  # 37
     resp, w = await test_query_handler.to_canonical_variation(
@@ -268,3 +478,9 @@ async def test_invalid(test_query_handler):
         q, fmt="spdi", do_liftover=True)
     assert resp.variation.type == "Text"
     assert w == ["Expected to find reference sequence A but found C on NC_000001.11"]
+
+    q = " NC_000013.11:g.20189349del "  # 38
+    resp, w = await test_query_handler.to_canonical_variation(
+        q, fmt="hgvs", hgvs_dup_del_mode="absolute_cnv")
+    assert resp.variation.type == "Text"
+    assert w == ["absolute_cnv requires `baseline_copies`"]

--- a/variation/hgvs_dup_del_mode.py
+++ b/variation/hgvs_dup_del_mode.py
@@ -1,6 +1,6 @@
 """Module for hgvs_dup_del_mode in normalize endpoint."""
 import logging
-from typing import Optional, Dict, Tuple, List, Union
+from typing import Optional, Dict, Tuple, List
 import copy
 import json
 
@@ -8,8 +8,7 @@ from ga4gh.vrs import models
 from ga4gh.core import ga4gh_identify, sha512t24u
 from uta_tools.data_sources import SeqRepoAccess
 
-from variation.schemas.hgvs_to_copy_number_schema import CopyNumberType, \
-    RelativeCopyClass
+from variation.schemas.hgvs_to_copy_number_schema import RelativeCopyClass
 from variation.schemas.normalize_response_schema\
     import HGVSDupDelMode as HGVSDupDelModeEnum
 
@@ -28,8 +27,9 @@ class HGVSDupDelMode:
         self.seqrepo_access = seqrepo_access
         self.valid_dup_del_modes = {mode.value for mode in
                                     HGVSDupDelModeEnum.__members__.values()}
-        self.valid_copy_number_modes = {cn_type.value for cn_type in
-                                        CopyNumberType.__members__.values()}
+        self.valid_copy_number_modes = {mode.value for mode in
+                                        HGVSDupDelModeEnum.__members__.values() if
+                                        mode.value.endswith("_cnv")}
 
     def is_valid_dup_del_mode(self, mode: str) -> bool:
         """Determine if mode is a valid input for HGVS Dup Del Mode.
@@ -73,46 +73,97 @@ class HGVSDupDelMode:
         :return: VRS Variation object represented as a dict
         """
         if "uncertain" in alt_type or "range" in alt_type:
-            variation = self.cnv_mode(ac, del_or_dup,
-                                      location, chromosome=chromosome)
+            variation = self.absolute_copy_number_mode(ac, del_or_dup, location,
+                                                       chromosome=chromosome)
         elif pos and (pos[1] - pos[0] > 100):
             variation = self.repeated_seq_expr_mode(alt_type, location)
         else:
             variation = self.literal_seq_expr_mode(allele, alt_type)
         return variation
 
-    def cnv_mode(self, ac: str, del_or_dup: str, location: Dict,
-                 chromosome: str = None) -> Optional[Dict]:
+    def _ga4gh_identify_cnv(self, variation: Dict, is_abs: bool = True) -> Dict:
+        """Add ga4gh digest to variation
+
+        :param Dict variation: VRS Copy Number Variation
+        :param bool is_abs: `True` if Absolute Copy Number.
+            `False` if Relative Copy Number.
+        :return: Variation with ga4gh digest identifiers
+        """
+        copy_variation = copy.deepcopy(variation)
+        location_id = variation["subject"]["_id"].split(".")[-1]
+        copy_variation["subject"] = location_id
+        serialized = json.dumps(
+            copy_variation, sort_keys=True, separators=(",", ":"), indent=None
+        ).encode("utf-8")
+        digest = sha512t24u(serialized)
+        if is_abs:
+            variation["_id"] = f"ga4gh:VAC.{digest}"
+        else:
+            variation["_id"] = f"ga4gh:VRC.{digest}"
+        return variation
+
+    def absolute_copy_number_mode(
+        self, ac: str, del_or_dup: str, location: Dict,
+        chromosome: Optional[str] = None, baseline_copies: Optional[int] = None
+    ) -> Optional[Dict]:
         """Return a VRS Copy Number Variation.
 
         :param str ac: Accession
         :param str del_or_dup: Must be either `del` or `dup`
         :param Dict location: VRS SequenceLocation
-        :param str chromosome: Chromosome
+        :param Optional[str] chromosome: Chromosome
+        :param Optional[int] baseline_copies: Baseline copies number
         :return: VRS Copy Number object represented as a dict
         """
-        if chromosome is None:
-            chromosome, _ = self.seqrepo_access.ac_to_chromosome(ac)
-
-        if chromosome is None:
-            logger.warning(f"Unable to find chromosome on {ac}")
-            return None
-        if chromosome == "X":
-            copies = models.DefiniteRange(
-                min=0 if del_or_dup == "del" else 2,
-                max=1 if del_or_dup == "del" else 3,
-                type="DefiniteRange"
-            )
-        elif chromosome == "Y":
+        if baseline_copies:
             copies = models.Number(
-                value=0 if del_or_dup == "del" else 2, type="Number"
+                value=baseline_copies - 1 if del_or_dup == "del" else baseline_copies + 1,  # noqa: E501
+                type="Number"
             )
         else:
-            # Chr 1-22
-            copies = models.Number(
-                value=1 if del_or_dup == "del" else 3, type="Number"
-            )
-        return self._abs_cnv(location, copies)
+            if chromosome is None:
+                chromosome, _ = self.seqrepo_access.ac_to_chromosome(ac)
+
+            if chromosome is None:
+                logger.warning(f"Unable to find chromosome on {ac}")
+                return None
+            if chromosome == "X":
+                copies = models.DefiniteRange(
+                    min=0 if del_or_dup == "del" else 2,
+                    max=1 if del_or_dup == "del" else 3,
+                    type="DefiniteRange"
+                )
+            elif chromosome == "Y":
+                copies = models.Number(
+                    value=0 if del_or_dup == "del" else 2, type="Number"
+                )
+            else:
+                # Chr 1-22
+                copies = models.Number(
+                    value=1 if del_or_dup == "del" else 3, type="Number"
+                )
+        variation = {
+            "type": "AbsoluteCopyNumber",
+            "subject": location,
+            "copies": copies.as_dict()
+        }
+        return self._ga4gh_identify_cnv(variation, is_abs=True)
+
+    def relative_copy_number_mode(
+        self, location: Dict, relative_copy_class: RelativeCopyClass
+    ) -> Optional[Dict]:
+        """Return relative copy number variation
+
+        :param Dict location: VRS SequenceLocation
+        :param RelativeCopyClass relative_copy_class: The relative copy class
+        :return: Relative copy number variation as a dict
+        """
+        variation = {
+            "type": "RelativeCopyNumber",
+            "subject": location,
+            "relative_copy_class": relative_copy_class
+        }
+        return self._ga4gh_identify_cnv(variation, is_abs=False)
 
     def repeated_seq_expr_mode(self, alt_type: str,
                                location: Dict) -> Optional[Dict]:
@@ -211,97 +262,18 @@ class HGVSDupDelMode:
                     ac, alt_type, pos, del_or_dup,
                     allele["location"], allele=allele
                 )
-            elif hgvs_dup_del_mode == HGVSDupDelModeEnum.CNV:
-                variation = self.cnv_mode(ac, del_or_dup, allele["location"])
             elif hgvs_dup_del_mode == HGVSDupDelModeEnum.REPEATED_SEQ_EXPR:
                 variation = self.repeated_seq_expr_mode(
                     alt_type, allele["location"]
                 )
             elif hgvs_dup_del_mode == HGVSDupDelModeEnum.LITERAL_SEQ_EXPR:
                 variation = self.literal_seq_expr_mode(allele, alt_type)
-            elif hgvs_dup_del_mode == CopyNumberType.ABSOLUTE:
+            elif hgvs_dup_del_mode == HGVSDupDelModeEnum.ABSOLUTE_CNV:
                 variation = self.absolute_copy_number_mode(
                     ac, del_or_dup, allele["location"], baseline_copies=baseline_copies)
-            elif hgvs_dup_del_mode == CopyNumberType.RELATIVE:
+            elif hgvs_dup_del_mode == HGVSDupDelModeEnum.RELATIVE_CNV:
                 variation = self.relative_copy_number_mode(
                     allele["location"], relative_copy_class)
             if not variation:
                 errors.append("Unable to get VRS Variation")
         return variation
-
-    def _ga4gh_identify_cnv(self, variation: Dict, is_abs: bool = True) -> Dict:
-        """Add ga4gh digest to variation
-
-        :param Dict variation: VRS Copy Number Variation
-        :param bool is_abs: `True` if Absolute Copy Number.
-            `False` if Relative Copy Number.
-        :return: Variation with ga4gh digest identifiers
-        """
-        copy_variation = copy.deepcopy(variation)
-        location_id = variation["subject"]["_id"].split(".")[-1]
-        copy_variation["subject"] = location_id
-        serialized = json.dumps(
-            copy_variation, sort_keys=True, separators=(",", ":"), indent=None
-        ).encode("utf-8")
-        digest = sha512t24u(serialized)
-        if is_abs:
-            variation["_id"] = f"ga4gh:VAC.{digest}"
-        else:
-            variation["_id"] = f"ga4gh:VRC.{digest}"
-        return variation
-
-    def _abs_cnv(
-        self, location: Dict,
-        copies: Union[models.DefiniteRange, models.Number, models.IndefiniteRange]
-    ) -> Dict:
-        """Return absolute copy number variation with ga4gh digest as optional id
-
-        :param Union[models.DefiniteRange, models.Number, models.IndefiniteRange] copies:  # noqa E501
-            Copies for absolute copy number variation
-        :param Dict location: VRS SequenceLocation
-        :return: VRS Absolute Copy Number object represented as a dict
-        """
-        variation = {
-            "type": "AbsoluteCopyNumber",
-            "subject": location,
-            "copies": copies.as_dict()
-        }
-        return self._ga4gh_identify_cnv(variation, is_abs=True)
-
-    def absolute_copy_number_mode(
-        self, ac: str, del_or_dup: str, location: Dict,
-        chromosome: Optional[str] = None, baseline_copies: Optional[int] = None
-    ) -> Optional[Dict]:
-        """Return absolute copy number variation
-
-        :param str ac: Accession
-        :param str del_or_dup: Must be either `del` or `dup`
-        :param Dict location: VRS SequenceLocation
-        :param str chromosome: Chromosome
-        :param Optional[int] baseline_copies: Baseline copies number
-        :return: Absolute copy number variation as a dict
-        """
-        if baseline_copies:
-            copies = models.Number(
-                value=baseline_copies - 1 if del_or_dup == "del" else baseline_copies + 1,  # noqa: E501
-                type="Number"
-            )
-            return self._abs_cnv(location, copies)
-        else:
-            return self.cnv_mode(ac, del_or_dup, location, chromosome)
-
-    def relative_copy_number_mode(
-        self, location: Dict, relative_copy_class: RelativeCopyClass
-    ) -> Optional[Dict]:
-        """Return relative copy number variation
-
-        :param Dict location: VRS SequenceLocation
-        :param RelativeCopyClass relative_copy_class: The relative copy class
-        :return: Relative copy number variation as a dict
-        """
-        variation = {
-            "type": "RelativeCopyNumber",
-            "subject": location,
-            "relative_copy_class": relative_copy_class
-        }
-        return self._ga4gh_identify_cnv(variation, is_abs=False)

--- a/variation/hgvs_dup_del_mode.py
+++ b/variation/hgvs_dup_del_mode.py
@@ -54,8 +54,8 @@ class HGVSDupDelMode:
                      chromosome: str = None,
                      allele: Dict = None) -> Optional[Dict]:
         """Use default characteristics to return a variation.
-        If endpoints are ambiguous: cnv
-            handling X chromosome, make cnv a definite range with base 1-2
+        If endpoints are ambiguous: absolute_cnv
+            handling X chromosome, make absolute_cnv a definite range with base 1-2
             handling Y chromosome, base of 1
             handling anything else, base of 2
         elif len del or dup > 100bp:

--- a/variation/main.py
+++ b/variation/main.py
@@ -118,9 +118,9 @@ hgvs_dup_del_mode_decsr = ("Must be one of: `default`, `absolute_cnv`, `relative
 async def normalize(
     q: str = Query(..., description=q_description),
     hgvs_dup_del_mode: Optional[HGVSDupDelModeEnum] = Query(
-        None, description=hgvs_dup_del_mode_decsr),
+        HGVSDupDelModeEnum.DEFAULT, description=hgvs_dup_del_mode_decsr),
     baseline_copies: Optional[int] = Query(
-        None, description="Baseline copies for HGVS duplications and deletions"),
+        None, description="Baseline copies for HGVS duplications and deletions represented as Absolute Copy Number Variation"),  # noqa: E501
     relative_copy_class: Optional[RelativeCopyClass] = Query(
         None, description="The relative copy class for HGVS duplications and deletions represented as Relative Copy Number Variation.")  # noqa: E501
 ) -> NormalizeService:
@@ -296,6 +296,10 @@ hgvs_dup_del_mode_decsr = "This parameter determines how to interpret HGVS dup/d
                           "expressions in VRS. Must be one of: `default`, " \
                           "`absolute_cnv`, `relative_cnv`, `repeated_seq_expr`, " \
                           "`literal_seq_expr`."
+relative_copy_class_descr = "The relative copy class. Only used when `fmt`=`hgvs` "\
+                            "and Relative CNV."
+baseline_copies_descr = "Baseline copies for duplication or deletion. Only used when "\
+                        "`fmt`=`hgvs` and Absolute CNV.`"
 
 
 @app.get("/variation/to_canonical_variation",
@@ -313,11 +317,11 @@ async def to_canonical_variation(
         do_liftover: bool = Query(False, description="Whether or not to liftover to "
                                   "GRCh38 assembly."),
         hgvs_dup_del_mode: Optional[HGVSDupDelModeEnum] = Query(
-            None, description=hgvs_dup_del_mode_decsr),
+            HGVSDupDelModeEnum.DEFAULT, description=hgvs_dup_del_mode_decsr),
         relative_copy_class: Optional[RelativeCopyClass] = Query(
-            None, description="The relative copy class"),
+            None, description=relative_copy_class_descr),
         baseline_copies: Optional[int] = Query(
-            None, description="Baseline copies for duplication or deletion")
+            None, description=baseline_copies_descr)
 ) -> ToCanonicalVariationService:
     """Return categorical variation for canonical SPDI
 
@@ -331,8 +335,10 @@ async def to_canonical_variation(
     :param Optional[HGVSDupDelModeEnum] hgvs_dup_del_mode: Determines how to interpret
         HGVS dup/del expressions in VRS. Must be one of: `default`, `absolute_cnv`,
         `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`
-    :param Optional[RelativeCopyClass] relative_copy_class: Relative copy class
+    :param Optional[RelativeCopyClass] relative_copy_class: Relative copy class.
+        Only used when `fmt`=`hgvs` and Relative CNV.
     :param Optional[int] baseline_copies: Baseline copies number
+        Only used when `fmt`=`hgvs` and Absolute CNV
     :return: ToCanonicalVariationService for variation query
     """
     q = unquote(q)

--- a/variation/main.py
+++ b/variation/main.py
@@ -118,7 +118,11 @@ hgvs_dup_del_mode_decsr = ("Must be one of: `default`, `absolute_cnv`, `relative
 async def normalize(
     q: str = Query(..., description=q_description),
     hgvs_dup_del_mode: Optional[HGVSDupDelModeEnum] = Query(
-        None, description=hgvs_dup_del_mode_decsr)
+        None, description=hgvs_dup_del_mode_decsr),
+    baseline_copies: Optional[int] = Query(
+        None, description="Baseline copies for HGVS duplications and deletions"),
+    relative_copy_class: Optional[RelativeCopyClass] = Query(
+        None, description="The relative copy class for HGVS duplications and deletions represented as Relative Copy Number Variation.")  # noqa: E501
 ) -> NormalizeService:
     """Return Value Object Descriptor for variation.
 
@@ -127,10 +131,16 @@ async def normalize(
         Must be: `default`, `absolute_cnv`, `relative_cnv`, `repeated_seq_expr`,
         `literal_seq_expr`. This parameter determines how to interpret HGVS dup/del
         expressions in VRS.
+    :param Optional[int] baseline_copies: Baseline copies for HGVS duplications and
+        deletions
+    :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
+        for HGVS duplications and deletions represented as Relative Copy Number
+        Variation.
     :return: NormalizeService for variation
     """
     normalize_resp = await query_handler.normalize(
-        unquote(q), hgvs_dup_del_mode=hgvs_dup_del_mode)
+        unquote(q), hgvs_dup_del_mode=hgvs_dup_del_mode,
+        baseline_copies=baseline_copies, relative_copy_class=relative_copy_class)
     warnings = query_handler.normalize_handler.warnings if \
         query_handler.normalize_handler.warnings else None
 
@@ -282,6 +292,10 @@ async def gnomad_vcf_to_protein(
 complement_descr = "This field indicates that a categorical variation is defined to " \
                    "include (false) or exclude (true) variation concepts matching " \
                    "the categorical variation."
+hgvs_dup_del_mode_decsr = "This parameter determines how to interpret HGVS dup/del "\
+                          "expressions in VRS. Must be one of: `default`, " \
+                          "`absolute_cnv`, `relative_cnv`, `repeated_seq_expr`, " \
+                          "`literal_seq_expr`."
 
 
 @app.get("/variation/to_canonical_variation",
@@ -297,7 +311,13 @@ async def to_canonical_variation(
                                              description="Format of the input variation. Must be `spdi` or `hgvs`"),  # noqa: E501
         complement: bool = Query(False, description=complement_descr),
         do_liftover: bool = Query(False, description="Whether or not to liftover to "
-                                  "GRCh38 assembly.")
+                                  "GRCh38 assembly."),
+        hgvs_dup_del_mode: Optional[HGVSDupDelModeEnum] = Query(
+            None, description=hgvs_dup_del_mode_decsr),
+        relative_copy_class: Optional[RelativeCopyClass] = Query(
+            None, description="The relative copy class"),
+        baseline_copies: Optional[int] = Query(
+            None, description="Baseline copies for duplication or deletion")
 ) -> ToCanonicalVariationService:
     """Return categorical variation for canonical SPDI
 
@@ -308,11 +328,18 @@ async def to_canonical_variation(
         is defined to include (false) or exclude (true) variation concepts matching the
         categorical variation. This is equivalent to a logical NOT operation on the
         categorical variation properties.
+    :param Optional[HGVSDupDelModeEnum] hgvs_dup_del_mode: Determines how to interpret
+        HGVS dup/del expressions in VRS. Must be one of: `default`, `absolute_cnv`,
+        `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`
+    :param Optional[RelativeCopyClass] relative_copy_class: Relative copy class
+    :param Optional[int] baseline_copies: Baseline copies number
     :return: ToCanonicalVariationService for variation query
     """
     q = unquote(q)
     variation, warnings = await query_handler.to_canonical_variation(
-        q, fmt, complement, do_liftover)
+        q, fmt, complement, do_liftover=do_liftover,
+        hgvs_dup_del_mode=hgvs_dup_del_mode, baseline_copies=baseline_copies,
+        relative_copy_class=relative_copy_class)
 
     return ToCanonicalVariationService(
         query=q,

--- a/variation/main.py
+++ b/variation/main.py
@@ -102,7 +102,7 @@ normalize_response_description = "A response to a validly-formed query."
 normalize_description = \
     "Return VRSATILE compatible object for variation provided."
 q_description = "Variation to normalize."
-hgvs_dup_del_mode_decsr = ("Must be one of: `default`, `cnv`, "
+hgvs_dup_del_mode_decsr = ("Must be one of: `default`, `absolute_cnv`, `relative_cnv`, "
                            "`repeated_seq_expr`, `literal_seq_expr`. This"
                            " parameter determines how to interpret HGVS "
                            "dup/del expressions in VRS.")
@@ -124,9 +124,9 @@ async def normalize(
 
     :param str q: Variation to normalize
     :param Optional[HGVSDupDelModeEnum] hgvs_dup_del_mode:
-        Must be: `default`, `cnv`, `repeated_seq_expr`, `literal_seq_expr`.
-        This parameter determines how to interpret HGVS dup/del expressions
-        in VRS.
+        Must be: `default`, `absolute_cnv`, `relative_cnv`, `repeated_seq_expr`,
+        `literal_seq_expr`. This parameter determines how to interpret HGVS dup/del
+        expressions in VRS.
     :return: NormalizeService for variation
     """
     normalize_resp = await query_handler.normalize(

--- a/variation/normalize.py
+++ b/variation/normalize.py
@@ -2,7 +2,7 @@
 from typing import Optional, List, Tuple, Dict
 from urllib.parse import quote
 
-from ga4gh.vrsatile.pydantic.vrs_models import Text
+from ga4gh.vrsatile.pydantic.vrs_models import Text, VRSTypes
 from ga4gh.vrsatile.pydantic.vrsatile_models import VariationDescriptor, \
     GeneDescriptor
 from ga4gh.vrs import models
@@ -133,11 +133,12 @@ class Normalize:
         if "uncertain" in token_type:
             warnings = ["Ambiguous regions cannot be normalized"]
         elif "range" not in token_type:
-            if variation["type"] == "Allele":
+            if variation["type"] == VRSTypes.ALLELE.value:
                 vrs_ref_allele_seq = self.get_ref_allele_seq(
                     variation, identifier
                 )
-            elif variation["type"] == "AbsoluteCopyNumber":
+            elif variation["type"] in [VRSTypes.ABSOLUTE_COPY_NUMBER.value,
+                                       VRSTypes.RELATIVE_COPY_NUMBER.value]:
                 loc = {
                     "location": variation["subject"]
                 }

--- a/variation/query.py
+++ b/variation/query.py
@@ -150,9 +150,9 @@ class QueryHandler:
         :param q: Variation to normalize
         :param Optional[HGVSDupDelModeEnum] hgvs_dup_del_mode:
             Must be set when querying HGVS dup/del expressions.
-            Must be: `default`, `cnv`, `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to interpret HGVS dup/del expressions
-            in VRS.
+            Must be: `default`, `absolute_cnv`, `relative_cnv`, `repeated_seq_expr`,
+            `literal_seq_expr`. This parameter determines how to interpret HGVS dup/del
+            expressions in VRS.
         :return: Variation Descriptor for variation
         """
         validations, warnings = await self.to_vrs_handler.get_validations(

--- a/variation/schemas/hgvs_to_copy_number_schema.py
+++ b/variation/schemas/hgvs_to_copy_number_schema.py
@@ -1,5 +1,4 @@
 """Module containing schemas used in HGVS To Copy Number endpoints"""
-from enum import Enum
 from typing import Type, Any, Dict, Union
 
 from ga4gh.vrsatile.pydantic.vrs_models import RelativeCopyClass, AbsoluteCopyNumber, \
@@ -16,14 +15,6 @@ VALID_CLASSIFICATION_TYPES = [
     ClassificationType.GENOMIC_DELETION_RANGE,
     ClassificationType.GENOMIC_UNCERTAIN_DELETION
 ]
-
-
-class CopyNumberType(str, Enum):
-    """Define copy number types"""
-
-    RELATIVE = "relative_copy_number"
-    ABSOLUTE = "absolute_copy_number"
-
 
 VALID_RELATIVE_COPY_CLASS = [rcc.value for
                              rcc in RelativeCopyClass.__members__.values()]

--- a/variation/schemas/normalize_response_schema.py
+++ b/variation/schemas/normalize_response_schema.py
@@ -17,8 +17,8 @@ class HGVSDupDelMode(str, Enum):
     DEFAULT = "default"
     ABSOLUTE_CNV = "absolute_cnv"
     RELATIVE_CNV = "relative_cnv"
-    REPEATED_SEQ_EXPR = "repeated_seq_expr"
-    LITERAL_SEQ_EXPR = "literal_seq_expr"
+    REPEATED_SEQ_EXPR = "repeated_seq_expr"  # VRS Allele
+    LITERAL_SEQ_EXPR = "literal_seq_expr"  # VRS Allele
 
 
 class ServiceMeta(BaseModel):

--- a/variation/schemas/normalize_response_schema.py
+++ b/variation/schemas/normalize_response_schema.py
@@ -15,7 +15,8 @@ class HGVSDupDelMode(str, Enum):
     """
 
     DEFAULT = "default"
-    CNV = "cnv"
+    ABSOLUTE_CNV = "absolute_cnv"
+    RELATIVE_CNV = "relative_cnv"
     REPEATED_SEQ_EXPR = "repeated_seq_expr"
     LITERAL_SEQ_EXPR = "literal_seq_expr"
 

--- a/variation/to_vrs.py
+++ b/variation/to_vrs.py
@@ -112,11 +112,10 @@ class ToVRS:
                             warnings.append(f"hgvs_dup_del_mode must be one of "
                                             f"{self.hgvs_dup_del_mode.valid_copy_number_modes}")  # noqa: E501
                             return None, warnings
-
-                    if hgvs_dup_del_mode == HGVSDupDelModeEnum.RELATIVE_CNV:
-                        if not relative_copy_class:
+                    if hgvs_dup_del_mode == HGVSDupDelModeEnum.ABSOLUTE_CNV:
+                        if not baseline_copies:
                             warnings.append(f"{hgvs_dup_del_mode} mode "
-                                            f"requires `relative_copy_class`")
+                                            f"requires `baseline_copies`")
                             return None, warnings
                 elif not hgvs_dup_del_mode and endpoint_name == Endpoint.NORMALIZE:
                     hgvs_dup_del_mode = HGVSDupDelModeEnum.DEFAULT

--- a/variation/to_vrs.py
+++ b/variation/to_vrs.py
@@ -10,8 +10,8 @@ from uta_tools.data_sources import SeqRepoAccess, TranscriptMappings, UTADatabas
 
 from variation.hgvs_dup_del_mode import HGVSDupDelMode
 from variation.schemas.app_schemas import Endpoint
-from variation.schemas.hgvs_to_copy_number_schema import VALID_CLASSIFICATION_TYPES, \
-    CopyNumberType, RelativeCopyClass
+from variation.schemas.hgvs_to_copy_number_schema import VALID_CLASSIFICATION_TYPES,\
+    RelativeCopyClass
 from variation.schemas.token_response_schema import Nomenclature
 from variation.schemas.validation_response_schema import ValidationSummary
 from variation.classifiers import Classify
@@ -71,7 +71,7 @@ class ToVRS:
 
     async def get_validations(
             self, q: str, endpoint_name: Optional[Endpoint] = None,
-            hgvs_dup_del_mode: Optional[Union[HGVSDupDelModeEnum, CopyNumberType]] = None,  # noqa: E501
+            hgvs_dup_del_mode: Optional[HGVSDupDelModeEnum] = None,  # noqa: E501
             baseline_copies: Optional[int] = None,
             relative_copy_class: Optional[RelativeCopyClass] = None,
             do_liftover: bool = False
@@ -80,9 +80,8 @@ class ToVRS:
 
         :param str q: variation to get validation results for
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
-        :param Optional[Union[HGVSDupDelModeEnum, CopyNumberType]] hgvs_dup_del_mode:
-            This parameter determines how to interpret HGVS dup/del expressions
-            in VRS.
+        :param Optional HGVSDupDelModeEnum hgvs_dup_del_mode: This parameter determines
+            how to interpret HGVS dup/del expressions in VRS.
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
         :param bool do_liftover: Whether or not to liftover to GRCh38 assembly
@@ -98,32 +97,34 @@ class ToVRS:
         if Nomenclature.GNOMAD_VCF in nomenclature:
             hgvs_dup_del_mode = HGVSDupDelModeEnum.LITERAL_SEQ_EXPR
         else:
-            if endpoint_name == Endpoint.NORMALIZE:
+            if endpoint_name in [Endpoint.NORMALIZE, Endpoint.HGVS_TO_ABSOLUTE_CN,
+                                 Endpoint.HGVS_TO_RELATIVE_CN]:
                 if hgvs_dup_del_mode:
                     hgvs_dup_del_mode = hgvs_dup_del_mode.strip().lower()
-                    if not self.hgvs_dup_del_mode.is_valid_dup_del_mode(hgvs_dup_del_mode):  # noqa: E501
-                        warnings.append(
-                            f"hgvs_dup_del_mode must be one of: "
-                            f"{self.hgvs_dup_del_mode.valid_dup_del_modes}")
-                        return None, warnings
-                else:
+                    if endpoint_name == Endpoint.NORMALIZE:
+                        if not self.hgvs_dup_del_mode.is_valid_dup_del_mode(hgvs_dup_del_mode):  # noqa: E501
+                            warnings.append(
+                                f"hgvs_dup_del_mode must be one of: "
+                                f"{self.hgvs_dup_del_mode.valid_dup_del_modes}")
+                            return None, warnings
+                    else:
+                        if not self.hgvs_dup_del_mode.is_valid_copy_number_mode(hgvs_dup_del_mode):  # noqa: E501
+                            warnings.append(f"hgvs_dup_del_mode must be one of "
+                                            f"{self.hgvs_dup_del_mode.valid_copy_number_modes}")  # noqa: E501
+                            return None, warnings
+
+                    if hgvs_dup_del_mode == HGVSDupDelModeEnum.RELATIVE_CNV:
+                        if not relative_copy_class:
+                            warnings.append(f"{hgvs_dup_del_mode} mode "
+                                            f"requires `relative_copy_class`")
+                            return None, warnings
+                elif not hgvs_dup_del_mode and endpoint_name == Endpoint.NORMALIZE:
                     hgvs_dup_del_mode = HGVSDupDelModeEnum.DEFAULT
-            elif endpoint_name in [Endpoint.HGVS_TO_ABSOLUTE_CN,
-                                   Endpoint.HGVS_TO_RELATIVE_CN]:
-                if not hgvs_dup_del_mode:
+                else:
                     warnings.append(f"hgvs_dup_del_mode must be either "
-                                    f"{CopyNumberType.ABSOLUTE.value} or "
-                                    f"{CopyNumberType.RELATIVE.value}")
+                                    f"{HGVSDupDelModeEnum.ABSOLUTE_CNV.value} or "
+                                    f"{HGVSDupDelModeEnum.RELATIVE_CNV.value}")
                     return None, warnings
-                if not self.hgvs_dup_del_mode.is_valid_copy_number_mode(hgvs_dup_del_mode):  # noqa: E501
-                    warnings.append(f"hgvs_dup_del_mode must be one of "
-                                    f"{self.hgvs_dup_del_mode.valid_copy_number_modes}")
-                    return None, warnings
-                if endpoint_name == Endpoint.HGVS_TO_RELATIVE_CN:
-                    if not relative_copy_class:
-                        warnings.append(f"{Endpoint.HGVS_TO_RELATIVE_CN} endpoint "
-                                        f"requires `relative_copy_class`")
-                        return None, warnings
             else:
                 hgvs_dup_del_mode = HGVSDupDelModeEnum.DEFAULT
 

--- a/variation/validators/coding_dna_deletion.py
+++ b/variation/validators/coding_dna_deletion.py
@@ -54,10 +54,9 @@ class CodingDNADeletion(DuplicationDeletionBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/coding_dna_delins.py
+++ b/variation/validators/coding_dna_delins.py
@@ -54,10 +54,9 @@ class CodingDNADelIns(DelInsBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/coding_dna_silent_mutation.py
+++ b/variation/validators/coding_dna_silent_mutation.py
@@ -54,10 +54,9 @@ class CodingDNASilentMutation(SingleNucleotideVariationBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/coding_dna_substitution.py
+++ b/variation/validators/coding_dna_substitution.py
@@ -57,10 +57,9 @@ class CodingDNASubstitution(SingleNucleotideVariationBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/delins_base.py
+++ b/variation/validators/delins_base.py
@@ -87,10 +87,9 @@ class DelInsBase(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/duplication_deletion_base.py
+++ b/variation/validators/duplication_deletion_base.py
@@ -118,10 +118,9 @@ class DuplicationDeletionBase(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
@@ -196,10 +195,9 @@ class DuplicationDeletionBase(Validator):
         :param str gene: Gene
         :param str so_id: Sequence ontology id
         :param List errors: List of errors
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Dict mane_data_found: MANE Transcript information found
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
@@ -292,10 +290,9 @@ class DuplicationDeletionBase(Validator):
         :param List errors: List of errors
         :param Dict grch38: GRCh38 data
         :param Dict mane_data_found: MANE data found for initial query
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optionals[Tuple] ival: Interval
         :param bool use_vrs_allele_range: `True` if allele should be computed
             using `to_vrs_allele_ranges` method. `False` if allele should be

--- a/variation/validators/duplication_deletion_base.py
+++ b/variation/validators/duplication_deletion_base.py
@@ -217,7 +217,7 @@ class DuplicationDeletionBase(Validator):
                 cds_start=mane["coding_start_site"])
 
             mane_variation = self.hgvs_dup_del_mode.interpret_variation(
-                t, s.alt_type, allele, errors, hgvs_dup_del_mode,
+                s.alt_type, allele, errors, hgvs_dup_del_mode,
                 baseline_copies=baseline_copies,
                 relative_copy_class=relative_copy_class)
 
@@ -315,7 +315,7 @@ class DuplicationDeletionBase(Validator):
                 s.alt_type, errors)
 
         grch38_variation = self.hgvs_dup_del_mode.interpret_variation(
-            t, s.alt_type, allele, errors, hgvs_dup_del_mode,
+            s.alt_type, allele, errors, hgvs_dup_del_mode,
             baseline_copies=baseline_copies, relative_copy_class=relative_copy_class)
 
         if grch38_variation:

--- a/variation/validators/genomic_deletion.py
+++ b/variation/validators/genomic_deletion.py
@@ -88,7 +88,7 @@ class GenomicDeletion(DuplicationDeletionBase):
                         s.coordinate_type, s.alt_type, errors)
 
                     variation = self.hgvs_dup_del_mode.interpret_variation(
-                        t, s.alt_type, allele, errors, hgvs_dup_del_mode,
+                        s.alt_type, allele, errors, hgvs_dup_del_mode,
                         pos=(start, end), relative_copy_class=relative_copy_class,
                         baseline_copies=baseline_copies
                     )

--- a/variation/validators/genomic_deletion.py
+++ b/variation/validators/genomic_deletion.py
@@ -56,10 +56,9 @@ class GenomicDeletion(DuplicationDeletionBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_deletion_range.py
+++ b/variation/validators/genomic_deletion_range.py
@@ -160,7 +160,7 @@ class GenomicDeletionRange(DuplicationDeletionBase):
                 pos = None
 
             variation = self.hgvs_dup_del_mode.interpret_variation(
-                t, s.alt_type, allele, errors,
+                s.alt_type, allele, errors,
                 hgvs_dup_del_mode, pos=pos, relative_copy_class=relative_copy_class,
                 baseline_copies=baseline_copies)
         return variation

--- a/variation/validators/genomic_deletion_range.py
+++ b/variation/validators/genomic_deletion_range.py
@@ -88,10 +88,9 @@ class GenomicDeletionRange(DuplicationDeletionBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_delins.py
+++ b/variation/validators/genomic_delins.py
@@ -55,10 +55,9 @@ class GenomicDelIns(DelInsBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_duplication.py
+++ b/variation/validators/genomic_duplication.py
@@ -57,10 +57,9 @@ class GenomicDuplication(DuplicationDeletionBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_duplication.py
+++ b/variation/validators/genomic_duplication.py
@@ -135,7 +135,7 @@ class GenomicDuplication(DuplicationDeletionBase):
                     t, start, end, s.coordinate_type,
                     s.alt_type, errors)
                 variation = self.hgvs_dup_del_mode.interpret_variation(
-                    t, s.alt_type, allele, errors, hgvs_dup_del_mode,
+                    s.alt_type, allele, errors, hgvs_dup_del_mode,
                     pos=(start, end), baseline_copies=baseline_copies,
                     relative_copy_class=relative_copy_class)
         elif s.token_type == TokenType.GENOMIC_DUPLICATION_RANGE:
@@ -152,7 +152,7 @@ class GenomicDuplication(DuplicationDeletionBase):
                 else:
                     pos = None
                 variation = self.hgvs_dup_del_mode.interpret_variation(
-                    t, s.alt_type, allele, errors,
+                    s.alt_type, allele, errors,
                     hgvs_dup_del_mode, pos=pos, baseline_copies=baseline_copies,
                     relative_copy_class=relative_copy_class)
         else:

--- a/variation/validators/genomic_silent_mutation.py
+++ b/variation/validators/genomic_silent_mutation.py
@@ -53,10 +53,9 @@ class GenomicSilentMutation(SingleNucleotideVariationBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_substitution.py
+++ b/variation/validators/genomic_substitution.py
@@ -53,10 +53,9 @@ class GenomicSubstitution(SingleNucleotideVariationBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_uncertain_deletion.py
+++ b/variation/validators/genomic_uncertain_deletion.py
@@ -57,10 +57,9 @@ class GenomicUncertainDeletion(DuplicationDeletionBase):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/genomic_uncertain_deletion.py
+++ b/variation/validators/genomic_uncertain_deletion.py
@@ -128,7 +128,7 @@ class GenomicUncertainDeletion(DuplicationDeletionBase):
             else:
                 pos = None
             variation = self.hgvs_dup_del_mode.interpret_variation(
-                t, s.alt_type, allele, errors,
+                s.alt_type, allele, errors,
                 hgvs_dup_del_mode, pos=pos, relative_copy_class=relative_copy_class,
                 baseline_copies=baseline_copies)
 

--- a/variation/validators/insertion_base.py
+++ b/variation/validators/insertion_base.py
@@ -39,10 +39,9 @@ class InsertionBase(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/polypeptide_sequence_variation_base.py
+++ b/variation/validators/polypeptide_sequence_variation_base.py
@@ -88,10 +88,9 @@ class PolypeptideSequenceVariationBase(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/protein_deletion.py
+++ b/variation/validators/protein_deletion.py
@@ -91,10 +91,9 @@ class ProteinDeletion(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/protein_delins.py
+++ b/variation/validators/protein_delins.py
@@ -91,10 +91,9 @@ class ProteinDelIns(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/protein_insertion.py
+++ b/variation/validators/protein_insertion.py
@@ -90,10 +90,9 @@ class ProteinInsertion(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/single_nucleotide_variation_base.py
+++ b/variation/validators/single_nucleotide_variation_base.py
@@ -87,10 +87,9 @@ class SingleNucleotideVariationBase(Validator):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class

--- a/variation/validators/validate.py
+++ b/variation/validators/validate.py
@@ -102,10 +102,9 @@ class Validate:
         :param List classifications: List of classifications
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param List warnings: List of warnings
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
         :param bool do_liftover: Whether or not to liftover to GRCh38 assembly

--- a/variation/validators/validator.py
+++ b/variation/validators/validator.py
@@ -135,10 +135,9 @@ class Validator(ABC):
         :param Dict mane_data_found: MANE Transcript information found
         :param bool is_identifier: `True` if identifier is given for exact
             location. `False` otherwise.
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
@@ -158,10 +157,9 @@ class Validator(ABC):
 
         :param Classification classification: A classification for a list of
             tokens
-        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `cnv`,
-            `repeated_seq_expr`, `literal_seq_expr`.
-            This parameter determines how to represent HGVS dup/del expressions
-            as VRS objects.
+        :param HGVSDupDelModeEnum hgvs_dup_del_mode: Must be: `default`, `absolute_cnv`,
+            `relative_cnv`, `repeated_seq_expr`, `literal_seq_expr`. This parameter
+            determines how to represent HGVS dup/del expressions as VRS objects.
         :param Optional[Endpoint] endpoint_name: Then name of the endpoint being used
         :param Optional[int] baseline_copies: Baseline copies number
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class


### PR DESCRIPTION
Closes #269 , #279 

Notes:
- Adds `relative_cnv` to `hgvs_dup_del_mode`
- `/to_canonical_variation` accepts `hgvs_dup_del_mode` to determine output when HGVS dup / del