### PR TITLE
refactor: service response

### DIFF
--- a/codebuild/deploy_eb_env_dev.py
+++ b/codebuild/deploy_eb_env_dev.py
@@ -3,7 +3,7 @@ import boto3
 import time
 elasticbeanstalk = boto3.client('elasticbeanstalk')
 servicecatalog = boto3.client('servicecatalog')
-terminate_time = 12
+terminate_time = 720
 eb_app_name = "VariationNormalization"
 eb_env_name = "VariationNormalization-dev-env"
 sc_product_id = "prod-mmw6ymv2ntzl2"

--- a/tests/test_gnomad_vcf_to_protein.py
+++ b/tests/test_gnomad_vcf_to_protein.py
@@ -726,12 +726,17 @@ async def test_deletion(test_handler, protein_deletion_np_range,
 @pytest.mark.asyncio
 async def test_invalid(test_handler):
     """Test that invalid queries return correct response"""
-    resp = await test_handler.gnomad_vcf_to_protein("BRAF V600E")
+    resp = await test_handler.gnomad_vcf_to_protein("dummy")
+    assert resp.variation_descriptor is None
+
+    resp = await test_handler.gnomad_vcf_to_protein("BRAF V600E",
+                                                    untranslatable_returns_text=True)
     assert resp.variation_descriptor.variation.type == "Text"
     assert resp.variation_descriptor.label == "BRAF V600E"
     assert resp.warnings == ["BRAF V600E is not a supported gnomad vcf query"]
 
-    resp = await test_handler.gnomad_vcf_to_protein("7-140753336-T-G")
+    resp = await test_handler.gnomad_vcf_to_protein("7-140753336-T-G",
+                                                    untranslatable_returns_text=True)
     assert resp.variation_descriptor.variation.type == "Text"
     assert resp.variation_descriptor.label == "7-140753336-T-G"
     assert set(resp.warnings) == {
@@ -739,7 +744,8 @@ async def test_invalid(test_handler):
         "Expected T but found A on NC_000007.14 at position 140753336",
     }
 
-    resp = await test_handler.gnomad_vcf_to_protein("20-2-TC-TG")
+    resp = await test_handler.gnomad_vcf_to_protein("20-2-TC-TG",
+                                                    untranslatable_returns_text=True)
     assert resp.variation_descriptor.variation.type == "Text"
     assert resp.variation_descriptor.label == "20-2-TC-TG"
     assert resp.warnings == ["Unable to get protein variation for 20-2-TC-TG"]

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -2455,7 +2455,8 @@ def genomic_del6_free_text_rse_lse(genomic_del6_free_text):
 async def assert_text_variation(query_list, test_handler):
     """Make assertion checks for invalid queries"""
     for q in query_list:
-        resp = await test_handler.normalize(q, "default")
+        resp = await test_handler.normalize(q, "default",
+                                            untranslatable_returns_text=True)
         assert resp.variation_descriptor.label == q.strip()
         assert (resp.variation_descriptor.variation.type == "Text"), q
 
@@ -2625,10 +2626,12 @@ async def test_genomic_dup3(test_handler, genomic_dup3_vrc, genomic_dup3_vac,
                                         relative_copy_class="low-level gain")
     assertion_checks(resp.variation_descriptor, genomic_dup3_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup3_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup3_rse_lse, q)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
@@ -2642,10 +2645,12 @@ async def test_genomic_dup3(test_handler, genomic_dup3_vrc, genomic_dup3_vac,
     assertion_checks(resp.variation_descriptor, genomic_dup3_vrc, q, ignore_id=True)
 
     genomic_dup3_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup3_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup3_rse_lse, q, ignore_id=True)
 
     # Free Text
@@ -2663,11 +2668,13 @@ async def test_genomic_dup3(test_handler, genomic_dup3_vrc, genomic_dup3_vac,
                          ignore_id=True)
 
         genomic_dup3_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup3_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup3_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -2696,10 +2703,12 @@ async def test_genomic_dup4(test_handler, genomic_dup4_vac, genomic_dup4_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_dup4_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup4_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup4_rse_lse, q)
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
@@ -2713,10 +2722,12 @@ async def test_genomic_dup4(test_handler, genomic_dup4_vac, genomic_dup4_vrc,
     assertion_checks(resp.variation_descriptor, genomic_dup4_vrc, q, ignore_id=True)
 
     genomic_dup4_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup4_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup4_rse_lse, q, ignore_id=True)
 
     # Free Text
@@ -2733,12 +2744,14 @@ async def test_genomic_dup4(test_handler, genomic_dup4_vac, genomic_dup4_vrc,
                          ignore_id=True)
 
         genomic_dup4_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         genomic_dup4_free_text_rse_lse.variation.definition = q
         assertion_checks(resp.variation_descriptor, genomic_dup4_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup4_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -2767,10 +2780,12 @@ async def test_genomic_dup5(test_handler, genomic_dup5_vac, genomic_dup5_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_dup5_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup5_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup5_rse_lse, q)
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
@@ -2784,10 +2799,12 @@ async def test_genomic_dup5(test_handler, genomic_dup5_vac, genomic_dup5_vrc,
     assertion_checks(resp.variation_descriptor, genomic_dup5_vrc, q, ignore_id=True)
 
     genomic_dup5_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup5_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup5_rse_lse, q, ignore_id=True)
 
     # Free Text
@@ -2804,11 +2821,13 @@ async def test_genomic_dup5(test_handler, genomic_dup5_vac, genomic_dup5_vrc,
                          ignore_id=True)
 
         genomic_dup5_free_text_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup5_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup5_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -2819,7 +2838,8 @@ async def test_genomic_dup5(test_handler, genomic_dup5_vac, genomic_dup5_vrc,
         "MECP2 g.(?_154021812)_154097733dup"  # 37
         "MECP2 g.(?_154021572)_154092209dup",  # 38
     ]:
-        resp = await test_handler.normalize(q, "default")
+        resp = await test_handler.normalize(q, "default",
+                                            untranslatable_returns_text=True)
         assert resp.variation_descriptor.variation.type == "Text"
 
 
@@ -2839,10 +2859,12 @@ async def test_genomic_dup6(test_handler, genomic_dup6_vac, genomic_dup6_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_dup6_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup6_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup6_rse_lse, q)
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
@@ -2856,10 +2878,12 @@ async def test_genomic_dup6(test_handler, genomic_dup6_vac, genomic_dup6_vrc,
     assertion_checks(resp.variation_descriptor, genomic_dup6_vrc, q, ignore_id=True)
 
     genomic_dup6_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup6_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_dup6_rse_lse, q, ignore_id=True)
 
     # Free Text
@@ -2876,11 +2900,13 @@ async def test_genomic_dup6(test_handler, genomic_dup6_vac, genomic_dup6_vrc,
                          ignore_id=True)
 
         genomic_dup6_free_text_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup6_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_dup6_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -2891,7 +2917,8 @@ async def test_genomic_dup6(test_handler, genomic_dup6_vac, genomic_dup6_vrc,
         "MECP2 g.154021812_(154097733_?)dup"  # 37
         "MECP2 g.154021572_(154092209_?)dup",  # 38
     ]:
-        resp = await test_handler.normalize(q, "default")
+        resp = await test_handler.normalize(q, "default",
+                                            untranslatable_returns_text=True)
         assert resp.variation_descriptor.variation.type == "Text"
 
 
@@ -3075,10 +3102,12 @@ async def test_genomic_del3(test_handler, genomic_del3_vac, genomic_del3_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_del3_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del3_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del3_rse_lse, q)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
@@ -3092,10 +3121,12 @@ async def test_genomic_del3(test_handler, genomic_del3_vac, genomic_del3_vrc,
     assertion_checks(resp.variation_descriptor, genomic_del3_vrc, q, ignore_id=True)
 
     genomic_del3_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del3_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del3_rse_lse, q, ignore_id=True)
 
     # Free Text
@@ -3112,11 +3143,13 @@ async def test_genomic_del3(test_handler, genomic_del3_vac, genomic_del3_vrc,
                          ignore_id=True)
 
         genomic_del3_free_text_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del3_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del3_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -3146,10 +3179,12 @@ async def test_genomic_del4(test_handler, genomic_del4_vac, genomic_del4_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_del4_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del4_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del4_rse_lse, q)
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
@@ -3163,10 +3198,12 @@ async def test_genomic_del4(test_handler, genomic_del4_vac, genomic_del4_vrc,
     assertion_checks(resp.variation_descriptor, genomic_del4_vrc, q, ignore_id=True)
 
     genomic_del4_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del4_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del4_rse_lse, q, ignore_id=True)
 
     q = "NC_000002.12:g.(?_110104900)_(110207160_?)del"
@@ -3191,11 +3228,13 @@ async def test_genomic_del4(test_handler, genomic_del4_vac, genomic_del4_vrc,
         assertion_checks(resp.variation_descriptor, genomic_del4_free_text_vac, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del4_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del4_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -3225,10 +3264,12 @@ async def test_genomic_del5(test_handler, genomic_del5_vac, genomic_del5_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_del5_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del5_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del5_rse_lse, q)
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
@@ -3242,10 +3283,12 @@ async def test_genomic_del5(test_handler, genomic_del5_vac, genomic_del5_vrc,
     assertion_checks(resp.variation_descriptor, genomic_del5_vrc, q, ignore_id=True)
 
     genomic_del5_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del5_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del5_rse_lse, q, ignore_id=True)
 
     # Free text
@@ -3263,11 +3306,13 @@ async def test_genomic_del5(test_handler, genomic_del5_vac, genomic_del5_vrc,
                          ignore_id=True)
 
         genomic_del5_free_text_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del5_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del5_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -3298,10 +3343,12 @@ async def test_genomic_del6(test_handler, genomic_del6_vac, genomic_del6_vrc,
     resp = await test_handler.normalize(q, "relative_cnv")
     assertion_checks(resp.variation_descriptor, genomic_del6_vrc, q)
 
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del6_rse_lse, q)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del6_rse_lse, q)
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
@@ -3315,10 +3362,12 @@ async def test_genomic_del6(test_handler, genomic_del6_vac, genomic_del6_vrc,
     assertion_checks(resp.variation_descriptor, genomic_del6_vrc, q, ignore_id=True)
 
     genomic_del6_rse_lse.variation.definition = q
-    resp = await test_handler.normalize(q, "repeated_seq_expr")
+    resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del6_rse_lse, q, ignore_id=True)
 
-    resp = await test_handler.normalize(q, "literal_seq_expr")
+    resp = await test_handler.normalize(q, "literal_seq_expr",
+                                        untranslatable_returns_text=True)
     assertion_checks(resp.variation_descriptor, genomic_del6_rse_lse, q, ignore_id=True)
 
     # Free text
@@ -3336,11 +3385,13 @@ async def test_genomic_del6(test_handler, genomic_del6_vac, genomic_del6_vrc,
                          ignore_id=True)
 
         genomic_del6_rse_lse.variation.definition = q
-        resp = await test_handler.normalize(q, "repeated_seq_expr")
+        resp = await test_handler.normalize(q, "repeated_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del6_free_text_rse_lse, q,
                          ignore_id=True)
 
-        resp = await test_handler.normalize(q, "literal_seq_expr")
+        resp = await test_handler.normalize(q, "literal_seq_expr",
+                                            untranslatable_returns_text=True)
         assertion_checks(resp.variation_descriptor, genomic_del6_free_text_rse_lse, q,
                          ignore_id=True)
 
@@ -3377,7 +3428,7 @@ async def test_parameters(test_handler):
     assert resp.warnings == []
 
     resp = await test_handler.normalize(q, " absolute_CnV ")
-    assert not resp.variation_descriptor
+    assert resp.variation_descriptor is None
     assert resp.warnings == ["absolute_cnv mode requires `baseline_copies`"]
 
     resp = await test_handler.normalize(q, " relative_CnV ")

--- a/tests/test_hgvs_to_copy_number.py
+++ b/tests/test_hgvs_to_copy_number.py
@@ -1290,7 +1290,8 @@ async def test_invalid_cnv(test_handler):
     """Check that invalid input return warnings"""
     q = "DAG1 g.49568695dup"
     resp = await test_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=True)
+        q, relative_copy_class="low-level gain", do_liftover=True,
+        untranslatable_returns_text=True)
     assert set(resp.warnings) == {"Unable to translate DAG1 g.49568695dup to copy number variation",  # noqa: E501
                                   "DAG1 g.49568695dup is not a supported HGVS genomic duplication or deletion"}  # noqa: E501
     assert resp.relative_copy_number.type == "Text"
@@ -1300,4 +1301,4 @@ async def test_invalid_cnv(test_handler):
         q, relative_copy_class="low-level gain", do_liftover=True)
     assert set(resp.warnings) == {"Unable to translate braf v600e to copy number variation",  # noqa: E501
                                   "braf v600e is not a supported HGVS genomic duplication or deletion"}  # noqa: E501
-    assert resp.relative_copy_number.type == "Text"
+    assert resp.relative_copy_number is None

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1225,18 +1225,13 @@ async def test_no_matches(test_handler):
         "NM_173851.3(SLC30A8):c.973C>T%20(p.Arg325Trp)"
     ]
     for q in queries:
-        resp = await test_handler.normalize(q)
+        resp = await test_handler.normalize(q, untranslatable_returns_text=True)
         assert resp.variation_descriptor.type == "VariationDescriptor", q
         assert resp.variation_descriptor.variation.type == "Text", q
         assert resp.variation_descriptor.label == q.strip(), q
 
     resp = await test_handler.normalize("clinvar:10")
-    assert resp.variation_descriptor.type == "VariationDescriptor"
-    assert resp.variation_descriptor.label == "clinvar:10"
-    assert resp.variation_descriptor.variation.type == "Text"
-    assert resp.variation_descriptor.variation.definition == "clinvar:10"
-    assert resp.variation_descriptor.variation.id == \
-        "ga4gh:VT.xw9m9LZAyn6Z2-GPGwcpDT0ixqCm5g36"
+    assert resp.variation_descriptor is None
 
     resp = await test_handler.normalize("   ")
     assert resp.variation_descriptor is None

--- a/tests/test_parsed_to_abs_cnv.py
+++ b/tests/test_parsed_to_abs_cnv.py
@@ -223,54 +223,56 @@ def test_invalid(test_handler):
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/443961/?new_evidence=true
     expected_w = ["NCBI36 assembly is not current supported"]
     resp = test_handler.parsed_to_abs_cnv(
-        2623228, 3150942, 3, assembly=ClinVarAssembly.NCBI36, chr="chr1")
+        2623228, 3150942, 3, assembly=ClinVarAssembly.NCBI36, chr="chr1",
+        untranslatable_returns_text=True)
     assert resp.absolute_copy_number.type == "Text"
     assert resp.warnings == expected_w
 
     resp = test_handler.parsed_to_abs_cnv(
-        2623228, 3150942, 3, assembly=ClinVarAssembly.HG18, chr="chr1")
+        2623228, 3150942, 3, assembly=ClinVarAssembly.HG18, chr="chr1",
+        untranslatable_returns_text=True)
     assert resp.absolute_copy_number.type == "Text"
     assert resp.warnings == expected_w
 
     # Must give both assembly + chr or accession
     expected_w = ["Must provide either `accession` or both `assembly` and `chr`."]
     resp = test_handler.parsed_to_abs_cnv(
-        31738809, 32217725, 2, assembly="hg38")
+        31738809, 32217725, 2, assembly="hg38", untranslatable_returns_text=True)
     assert resp.absolute_copy_number.type == "Text"
     assert resp.warnings == expected_w
 
     resp = test_handler.parsed_to_abs_cnv(
-        31738809, 32217725, 2, chr="chr15")
+        31738809, 32217725, 2, chr="chr15", untranslatable_returns_text=True)
     assert resp.absolute_copy_number.type == "Text"
     assert resp.warnings == expected_w
 
     resp = test_handler.parsed_to_abs_cnv(
-        31738809, 32217725, 2)
+        31738809, 32217725, 2, untranslatable_returns_text=True)
     assert resp.absolute_copy_number.type == "Text"
     assert resp.warnings == expected_w
 
     # invalid chr
     resp = test_handler.parsed_to_abs_cnv(
         10001, 1223133, 0, assembly=ClinVarAssembly.GRCH38, chr="z")
-    assert resp.absolute_copy_number.type == "Text"
+    assert resp.absolute_copy_number is None
     assert resp.warnings == \
         ["SeqRepo unable to get translated identifiers for GRCh38:z"]
 
     # invalid assembly
     resp = test_handler.parsed_to_abs_cnv(
-        10001, 1223133, 0, assembly="GRCh99", chr="Y")
-    assert resp.absolute_copy_number.type == "Text"
+        10001, 1223133, 0, assembly="GRCh99")
+    assert resp.absolute_copy_number is None
     assert resp.warnings
 
     # invalid accession
     resp = test_handler.parsed_to_abs_cnv(
         10491132, 10535643, 1, accession="NC_00002310")
-    assert resp.absolute_copy_number.type == "Text"
+    assert resp.absolute_copy_number is None
     assert resp.warnings == \
         ["SeqRepo unable to get translated identifiers for NC_00002310"]
 
     # Invalid position
     resp = test_handler.parsed_to_abs_cnv(
         31738809, 2302991250, 2, accession="NC_000015.10")
-    assert resp.absolute_copy_number.type == "Text"
+    assert resp.absolute_copy_number is None
     assert resp.warnings == ["Position out of range (2302991250)"]

--- a/tests/test_to_canonical_variation.py
+++ b/tests/test_to_canonical_variation.py
@@ -442,53 +442,54 @@ async def test_to_canonical_variation_insertions(test_handler, variation4):
 async def test_invalid(test_handler):
     """Test that invalid queries return the correct response"""
     resp = await test_handler.to_canonical_variation(
-        "NC_000013.11:201845654659346:GGG:GG", fmt="spdi")
+        "NC_000013.11:201845654659346:GGG:GG", fmt="spdi",
+        untranslatable_returns_text=True)
     assert resp.canonical_variation.variation.type == "Text"
     assert resp.warnings == ["start out of range (201845654659346)"]
 
     resp = await test_handler.to_canonical_variation(
-        "NC_000013.11:2018459346:GGG:GG", fmt="spdi")
+        "NC_000013.11:2018459346:GGG:GG", fmt="spdi", untranslatable_returns_text=True)
     assert resp.canonical_variation.variation.type == "Text"
     assert resp.warnings == ["Position, 2018459346, does not exist on NC_000013.11"]
 
     resp = await test_handler.to_canonical_variation(
-        "NC_000013.1:20189346:GGG:GG", fmt="spdi")
+        "NC_000013.1:20189346:GGG:GG", fmt="spdi", untranslatable_returns_text=True)
     assert resp.canonical_variation.variation.type == "Text"
     assert resp.warnings == ["vrs-python translator raised error: seqrepo could not "
                              "translate identifier 'refseq:NC_000013.1'"]
 
     resp = await test_handler.to_canonical_variation(
-        "NP_004324.2:p.Val600Glu", fmt="spdi")
+        "NP_004324.2:p.Val600Glu", fmt="spdi", untranslatable_returns_text=True)
     assert resp.canonical_variation.variation.type == "Text"
     assert resp.warnings == ["NP_004324.2:p.Val600Glu is not a valid SPDI expression"]
 
     resp = await test_handler.to_canonical_variation(
-        "NC_000013.11:20189346:GCG:GG", fmt="spdi")
+        "NC_000013.11:20189346:GCG:GG", fmt="spdi", untranslatable_returns_text=True)
     assert resp.canonical_variation.variation.type == "Text"
     assert resp.warnings ==\
            ["Expected to find reference sequence GCG but found GGG on NC_000013.11"]
 
     resp = await test_handler.to_canonical_variation(
         "NC_000007.14:140753335:A:T", fmt="hgvs")
-    assert resp.canonical_variation.variation.type == "Text"
+    assert resp.canonical_variation is None
     assert resp.warnings == \
         ["NC_000007.14:140753335:A:T is not a valid HGVS expression"]
 
     resp = await test_handler.to_canonical_variation(
         "NC_000007.14:g.140753336464564654A>T", fmt="hgvs")
-    assert resp.canonical_variation.variation.type == "Text"
+    assert resp.canonical_variation is None
     assert resp.warnings == ["Unable to find valid result for classifications:"
                              " {'genomic substitution'}"]
 
     q = "NC_000001.10:2160640:A:ACTC"
     resp = await test_handler.to_canonical_variation(
         q, fmt="spdi", do_liftover=True)
-    assert resp.canonical_variation.variation.type == "Text"
+    assert resp.canonical_variation is None
     assert resp.warnings == \
         ["Expected to find reference sequence A but found C on NC_000001.11"]
 
     q = " NC_000013.11:g.20189349del "  # 38
     resp = await test_handler.to_canonical_variation(
         q, fmt="hgvs", hgvs_dup_del_mode="absolute_cnv")
-    assert resp.canonical_variation.variation.type == "Text"
+    assert resp.canonical_variation is None
     assert resp.warnings == ["absolute_cnv requires `baseline_copies`"]

--- a/variation/gnomad_vcf_to_protein_variation.py
+++ b/variation/gnomad_vcf_to_protein_variation.py
@@ -15,7 +15,7 @@ from variation.hgvs_dup_del_mode import HGVSDupDelMode
 from variation.to_vrsatile import ToVRSATILE
 from variation.tokenizers.tokenize import Tokenize
 from variation.translators.translate import Translate
-from variation.utils import no_variation_entered, text_variation_resp
+from variation.utils import no_variation_entered, no_variation_resp
 from variation.validators.validate import Validate
 from variation.schemas.validation_response_schema import ValidationSummary
 from variation.schemas.token_response_schema import Nomenclature, Token, \
@@ -222,10 +222,15 @@ class GnomadVcfToProteinVariation(ToVRSATILE):
                 aa_alt += self.codon_table.table[alt[3 * i:(3 * i) + 3]]
             return aa_alt
 
-    async def gnomad_vcf_to_protein(self, q: str) -> NormalizeService:
+    async def gnomad_vcf_to_protein(
+        self, q: str, untranslatable_returns_text: bool = False
+    ) -> NormalizeService:
         """Get protein consequence for gnomad vcf
 
         :param str q: gnomad vcf (chr-pos-ref-alt)
+        :param bool untranslatable_returns_text: `True` return VRS Text Object when
+            unable to translate or normalize query. `False` return `None` when
+            unable to translate or normalize query.
         :return: Normalize Service containing variation descriptor and warnings
         """
         q = q.strip()
@@ -343,12 +348,15 @@ class GnomadVcfToProteinVariation(ToVRSATILE):
                     vd, warnings = valid_list[0]
                 else:
                     if all_warnings:
-                        vd, warnings = text_variation_resp(q, _id, all_warnings)
+                        vd, warnings = no_variation_resp(q, _id, all_warnings,
+                                                         untranslatable_returns_text)
                     else:
-                        vd, warnings = text_variation_resp(
-                            q, _id, [f"Unable to get protein variation for {q}"])
+                        vd, warnings = no_variation_resp(
+                            q, _id, [f"Unable to get protein variation for {q}"],
+                            untranslatable_returns_text)
             else:
-                vd, warnings = text_variation_resp(q, _id, warnings)
+                vd, warnings = no_variation_resp(q, _id, warnings,
+                                                 untranslatable_returns_text)
         else:
             vd, warnings = no_variation_entered()
 

--- a/variation/normalize.py
+++ b/variation/normalize.py
@@ -13,7 +13,7 @@ from variation.hgvs_dup_del_mode import HGVSDupDelMode
 from variation.tokenizers.tokenize import Tokenize
 from variation.translators.translate import Translate
 from variation.utils import get_mane_valid_result, no_variation_entered, \
-    text_variation_resp
+    no_variation_resp
 from variation.validators.validate import Validate
 from variation.schemas.app_schemas import Endpoint
 from variation.schemas.normalize_response_schema\
@@ -50,7 +50,8 @@ class Normalize(ToVRSATILE):
         self, q: str,
         hgvs_dup_del_mode: Optional[HGVSDupDelModeEnum] = HGVSDupDelModeEnum.DEFAULT,
         baseline_copies: Optional[int] = None,
-        relative_copy_class: Optional[RelativeCopyClass] = None
+        relative_copy_class: Optional[RelativeCopyClass] = None,
+        untranslatable_returns_text: bool = False
     ) -> NormalizeService:
         """Normalize a given variation.
 
@@ -65,6 +66,9 @@ class Normalize(ToVRSATILE):
         :param Optional[RelativeCopyClass] relative_copy_class: The relative copy class
             for HGVS duplications and deletions represented as Relative Copy Number
             Variation.
+        :param bool untranslatable_returns_text: `True` return VRS Text Object when
+            unable to translate or normalize query. `False` return `None` when
+            unable to translate or normalize query.
         :return: NormalizeService with variation descriptor and warnings
         """
         vd = None
@@ -89,7 +93,8 @@ class Normalize(ToVRSATILE):
                     if not label:
                         vd, warnings = no_variation_entered()
                     else:
-                        vd, warnings = text_variation_resp(label, _id, warnings)
+                        vd, warnings = no_variation_resp(label, _id, warnings,
+                                                         untranslatable_returns_text)
 
         return NormalizeService(
             variation_query=q,

--- a/variation/schemas/hgvs_to_copy_number_schema.py
+++ b/variation/schemas/hgvs_to_copy_number_schema.py
@@ -1,5 +1,5 @@
 """Module containing schemas used in HGVS To Copy Number endpoints"""
-from typing import Type, Any, Dict, Union
+from typing import Optional, Type, Any, Dict, Union
 
 from ga4gh.vrsatile.pydantic.vrs_models import RelativeCopyClass, AbsoluteCopyNumber, \
     RelativeCopyNumber, Text
@@ -24,7 +24,7 @@ class HgvsToAbsoluteCopyNumberService(ServiceResponse):
     """A response for translating HGVS to absolute copy number."""
 
     hgvs_expr: StrictStr
-    absolute_copy_number: Union[AbsoluteCopyNumber, Text]
+    absolute_copy_number: Optional[Union[AbsoluteCopyNumber, Text]]
 
     class Config:
         """Configure model."""
@@ -71,7 +71,7 @@ class HgvsToRelativeCopyNumberService(ServiceResponse):
     """A response for translating HGVS to relative copy number."""
 
     hgvs_expr: StrictStr
-    relative_copy_number: Union[RelativeCopyNumber, Text]
+    relative_copy_number: Optional[Union[RelativeCopyNumber, Text]]
 
     class Config:
         """Configure model."""

--- a/variation/schemas/normalize_response_schema.py
+++ b/variation/schemas/normalize_response_schema.py
@@ -243,7 +243,7 @@ class ToCanonicalVariationService(ServiceResponse):
     """A response model for the to canonical variation service"""
 
     query: str
-    canonical_variation: CanonicalVariation
+    canonical_variation: Optional[CanonicalVariation]
 
     class Config:
         """Configure model."""

--- a/variation/schemas/service_schema.py
+++ b/variation/schemas/service_schema.py
@@ -34,7 +34,7 @@ class ParsedToAbsCnvService(ServiceResponse):
     """A response for translating parsed components to Absolute Copy Number"""
 
     query: Optional[ParsedToAbsCnvQuery] = None
-    absolute_copy_number: Union[Text, AbsoluteCopyNumber]
+    absolute_copy_number: Optional[Union[Text, AbsoluteCopyNumber]]
 
     class Config:
         """Configure model."""

--- a/variation/schemas/to_vrs_response_schema.py
+++ b/variation/schemas/to_vrs_response_schema.py
@@ -15,7 +15,7 @@ class ToVRSService(BaseModel):
     search_term: StrictStr
     warnings: Optional[List[StrictStr]]
     variations: Optional[Union[List[Allele], List[Text], List[Haplotype],
-                               List[AbsoluteCopyNumber], List[VariationSet]]] = None
+                               List[AbsoluteCopyNumber], List[VariationSet]]] = []
     service_meta_: ServiceMeta
 
     class Config:

--- a/variation/to_vrs.py
+++ b/variation/to_vrs.py
@@ -187,22 +187,26 @@ class ToVRS(VRSRepresentation):
 
         return ref
 
-    async def to_vrs(self, q: str) -> ToVRSService:
+    async def to_vrs(self, q: str,
+                     untranslatable_returns_text: bool = False) -> ToVRSService:
         """Return a VRS-like representation of all validated variations for a query.  # noqa: E501
 
         :param str q: The variation to translate
+        :param bool untranslatable_returns_text: `True` return VRS Text Object when
+            unable to translate or normalize query. `False` returns empty list when
+            unable to translate or normalize query.
         :return: ToVRSService containing VRS variations and warnings
         """
         validations, warnings = await self.get_validations(q)
         translations, warnings = self.get_translations(validations, warnings)
 
         if not translations:
-            if q and q.strip():
+            if untranslatable_returns_text and q and q.strip():
                 text = models.Text(definition=q, type="Text")
                 text._id = ga4gh_identify(text)
                 translations = [Text(**text.as_dict())]
             else:
-                translations = None
+                translations = []
 
         return ToVRSService(
             search_term=q,

--- a/variation/utils.py
+++ b/variation/utils.py
@@ -44,24 +44,29 @@ def get_mane_valid_result(q: str, validations: ValidationSummary,
     return valid_result
 
 
-def text_variation_resp(
-        label: str, _id: str,
-        warnings: List) -> Tuple[VariationDescriptor, List]:
-    """Return text variation for queries that could not be normalized
+def no_variation_resp(
+    label: str, _id: str, warnings: List, untranslatable_returns_text: bool = False
+) -> Tuple[Optional[VariationDescriptor], List]:
+    """Return Variation Descriptor with variation set as Text or return `None` for
+    queries that could not be normalized
 
     :param str label: Initial input query
     :param str _id: _id field for variation descriptor
     :param List warnings: List of warnings
-    :return: Variation descriptor, warnings
+    :param bool untranslatable_returns_text: `True` return VRS Text Object when
+        unable to translate or normalize query. `False` return `None` when
+        unable to translate or normalize query.
+    :return: Variation descriptor or `None`, warnings
     """
     warning = f"Unable to translate {label}"
-    text = models.Text(definition=label, type="Text")
-    text._id = ga4gh_identify(text)
-    resp = VariationDescriptor(
-        id=_id,
-        label=label,
-        variation=Text(**text.as_dict())
-    )
+    if untranslatable_returns_text:
+        text = models.Text(definition=label, type="Text")
+        text._id = ga4gh_identify(text)
+        variation = Text(**text.as_dict())
+        resp = VariationDescriptor(id=_id, label=label, variation=variation)
+    else:
+        resp = None
+
     if not warnings:
         warnings.append(warning)
     return resp, warnings


### PR DESCRIPTION
Closes #315 

Notes:
- Add untranslatable_returns_text param to determine if returning VRS Text or None/Empty list
- Remove response_model_exclude_none parameter to allow None in the response
- Temporarily changes dev deployment to terminate after 30 days (will change back to 12 hours once prod is updated with changes in staging)