### PR TITLE
change: relative_copy_class uses EFO IDs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,9 +29,9 @@ pytest-asyncio = "*"
 fastapi = "*"
 uvicorn = "*"
 pydantic = "*"
-"ga4gh.vrs" = {version = ">=0.8.7dev0", extras = ["extras"]}
+"ga4gh.vrs" = {version = ">=0.8.7dev1", extras = ["extras"]}
 gene-normalizer = ">=0.2.6"
 pyliftover = "*"
 boto3 = "*"
-"ga4gh.vrsatile.pydantic" = ">=0.1.dev3"
+"ga4gh.vrsatile.pydantic" = ">=0.1.dev6"
 cool-seq-tool = ">=0.1.4"

--- a/docs/hgvs_dup_del_mode.md
+++ b/docs/hgvs_dup_del_mode.md
@@ -9,7 +9,7 @@ The mode can be set to `default`, `absolute_cnv`, `relative_cnv`, `repeated_seq_
 - if baseline_copies is not set and endpoints are ambiguous:
     - relative_cnv
     - if relative_copy_class not provided:
-        - relative_copy_class = `partial loss` if del, `low-level gain` if dup
+        - relative_copy_class = `EFO:0030067` (copy number loss) if del, `EFO:0030070` (copy number gain) if dup
 - elif baseline_copies is provided:
     - absolute_cnv
     - copies are baseline_copies + 1 for dup, baseline_copies - 1 for del

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ appdirs==1.4.4
 appnope==0.1.3 ; sys_platform == 'darwin'
 argon2-cffi==21.3.0 ; python_version >= '3.6'
 argon2-cffi-bindings==21.2.0 ; python_version >= '3.6'
-asttokens==2.1.0
+asttokens==2.2.1
 asyncpg==0.27.0 ; python_full_version >= '3.7.0'
 attrs==22.1.0 ; python_version >= '3.5'
 babel==2.11.0 ; python_version >= '3.6'
@@ -14,16 +14,17 @@ beautifulsoup4==4.11.1 ; python_full_version >= '3.6.0'
 biocommons.seqrepo==0.6.5
 bioutils==0.5.7 ; python_version >= '3.6'
 bleach==5.0.1 ; python_version >= '3.7'
-boto3==1.26.5
-botocore==1.29.5 ; python_version >= '3.7'
+boto3==1.26.28
+botocore==1.29.28 ; python_version >= '3.7'
 bs4==0.0.1
 canonicaljson==1.6.4 ; python_version >= '3.7'
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.12.7 ; python_version >= '3.6'
 cffi==1.15.1
 cfgv==3.3.1 ; python_full_version >= '3.6.1'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
 click==8.1.3 ; python_version >= '3.7'
 coloredlogs==15.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+comm==0.1.2 ; python_version >= '3.6'
 commonmark==0.9.1
 configparser==5.3.0 ; python_version >= '3.7'
 contourpy==1.0.6 ; python_version >= '3.7'
@@ -32,55 +33,57 @@ coverage==6.5.0
 coveralls==3.3.1
 cssselect==1.2.0 ; python_version >= '3.7'
 cycler==0.11.0 ; python_version >= '3.6'
-debugpy==1.6.3 ; python_version >= '3.7'
+debugpy==1.6.4 ; python_version >= '3.7'
 decorator==5.1.1 ; python_version >= '3.5'
 defusedxml==0.7.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 distlib==0.3.6
 docopt==0.6.2
 docutils==0.19 ; python_version >= '3.7'
 entrypoints==0.4 ; python_version >= '3.6'
-exceptiongroup==1.0.1 ; python_version < '3.11'
+exceptiongroup==1.0.4 ; python_version < '3.11'
 executing==1.2.0
-fake-useragent==0.1.14
-fastapi==0.86.0
+fake-useragent==1.1.1
+fastapi==0.88.0
 fastjsonschema==2.16.2
-filelock==3.8.0 ; python_version >= '3.7'
-flake8==5.0.4
+filelock==3.8.2 ; python_version >= '3.7'
+flake8==6.0.0
 flake8-annotations==2.9.1
 flake8-docstrings==1.6.0
-flake8-import-order==0.18.1
+flake8-import-order==0.18.2
 flake8-quotes==3.3.1
 fonttools==4.38.0 ; python_version >= '3.7'
-ga4gh.vrs[extras]==0.8.7.dev0
-ga4gh.vrsatile.pydantic==0.1.dev3
+ga4gh.vrs[extras]==0.8.7.dev1
+ga4gh.vrsatile.pydantic==0.1.dev6
 gene-normalizer==0.2.6
 h11==0.14.0 ; python_version >= '3.7'
-hgvs==1.5.2
+hgvs==1.5.4 ; python_version >= '3.6'
 humanfriendly==10.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-identify==2.5.8 ; python_version >= '3.7'
+identify==2.5.9 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
-importlib-metadata==5.0.0 ; python_version >= '3.7'
+importlib-metadata==5.1.0 ; python_version >= '3.7'
 inflection==0.5.1 ; python_version >= '3.5'
 iniconfig==1.1.1
-ipykernel==6.17.0
-ipython==8.6.0 ; python_version >= '3.8'
+ipykernel==6.19.2
+ipython==8.7.0 ; python_version >= '3.8'
 ipython-genutils==0.2.0
-ipywidgets==8.0.2 ; python_version >= '3.7'
+ipywidgets==8.0.3 ; python_version >= '3.7'
 jaraco.classes==3.2.3 ; python_version >= '3.7'
-jedi==0.18.1 ; python_version >= '3.6'
+jedi==0.18.2 ; python_version >= '3.6'
 jinja2==3.1.2 ; python_version >= '3.7'
 jmespath==1.0.1 ; python_version >= '3.7'
 json5==0.9.10
 jsonschema==3.2.0
 jupyter==1.0.0
-jupyter-client==7.4.4 ; python_version >= '3.7'
+jupyter-client==7.4.8 ; python_version >= '3.7'
 jupyter-console==6.4.4 ; python_version >= '3.7'
-jupyter-core==5.0.0 ; python_version >= '3.8'
-jupyter-server==1.23.0 ; python_version >= '3.7'
-jupyterlab==3.5.0
+jupyter-core==5.1.0 ; python_version >= '3.8'
+jupyter-events==0.4.0 ; python_version >= '3.7'
+jupyter-server==2.0.1 ; python_version >= '3.8'
+jupyter-server-terminals==0.4.2 ; python_version >= '3.8'
+jupyterlab==3.5.1
 jupyterlab-pygments==0.2.2 ; python_version >= '3.7'
-jupyterlab-server==2.16.2 ; python_version >= '3.7'
-jupyterlab-widgets==3.0.3 ; python_version >= '3.7'
+jupyterlab-server==2.16.5 ; python_version >= '3.7'
+jupyterlab-widgets==3.0.4 ; python_version >= '3.7'
 keyring==23.11.0 ; python_version >= '3.7'
 kiwisolver==1.4.4 ; python_version >= '3.7'
 lxml==4.9.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -92,16 +95,16 @@ mccabe==0.7.0 ; python_version >= '3.6'
 mistune==2.0.4
 more-itertools==9.0.0 ; python_version >= '3.7'
 nbclassic==0.4.8 ; python_version >= '3.7'
-nbclient==0.7.0 ; python_full_version >= '3.7.0'
-nbconvert==7.2.3 ; python_version >= '3.7'
+nbclient==0.7.2 ; python_full_version >= '3.7.0'
+nbconvert==7.2.6 ; python_version >= '3.7'
 nbformat==5.7.0 ; python_version >= '3.7'
 nest-asyncio==1.5.6 ; python_version >= '3.5'
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 notebook==6.5.2 ; python_version >= '3.7'
 notebook-shim==0.2.2 ; python_version >= '3.7'
-numpy==1.23.4 ; python_version >= '3.8'
-packaging==21.3 ; python_version >= '3.6'
-pandas==1.5.1 ; python_version >= '3.8'
+numpy==1.23.5 ; python_version >= '3.8'
+packaging==22.0 ; python_version >= '3.7'
+pandas==1.5.2 ; python_version >= '3.8'
 pandocfilters==1.5.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 parse==1.19.0
 parsley==1.3
@@ -109,23 +112,23 @@ parso==0.8.3 ; python_version >= '3.6'
 pexpect==4.8.0 ; sys_platform != 'win32'
 pickleshare==0.7.5
 pillow==9.3.0 ; python_version >= '3.7'
-pkginfo==1.8.3 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-platformdirs==2.5.3 ; python_version >= '3.7'
+pkginfo==1.9.2 ; python_version >= '3.6'
+platformdirs==2.6.0 ; python_version >= '3.7'
 pluggy==1.0.0 ; python_version >= '3.6'
 pre-commit==2.20.0
 prometheus-client==0.15.0 ; python_version >= '3.6'
-prompt-toolkit==3.0.32 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.36 ; python_full_version >= '3.6.2'
 psutil==5.9.4 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 psycopg2==2.9.5 ; python_version >= '3.6'
 psycopg2-binary==2.9.5
 ptyprocess==0.7.0
 pure-eval==0.2.2
-pycodestyle==2.9.1 ; python_version >= '3.6'
+pycodestyle==2.10.0 ; python_version >= '3.6'
 pycparser==2.21
 pydantic==1.10.2
 pydocstyle==6.1.1 ; python_version >= '3.6'
 pyee==8.2.2
-pyflakes==2.5.0 ; python_version >= '3.6'
+pyflakes==3.0.1 ; python_version >= '3.6'
 pygments==2.13.0 ; python_version >= '3.6'
 pyliftover==0.4
 pyparsing==3.0.9 ; python_full_version >= '3.6.8'
@@ -134,9 +137,10 @@ pyquery==1.4.3
 pyrsistent==0.19.2 ; python_version >= '3.7'
 pysam==0.20.0
 pytest==7.2.0
-pytest-asyncio==0.20.1
+pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+python-json-logger==2.0.4 ; python_version >= '3.5'
 python-jsonschema-objects==0.4.1
 pytz==2022.6
 pyyaml==6.0 ; python_version >= '3.6'
@@ -151,34 +155,34 @@ rfc3986==2.0.0 ; python_version >= '3.7'
 rich==12.6.0 ; python_full_version >= '3.6.3' and python_full_version < '4.0.0'
 s3transfer==0.6.0 ; python_version >= '3.7'
 send2trash==1.8.0
-setuptools==65.5.1 ; python_version >= '3.7'
-simplejson==3.17.6 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
+setuptools==65.6.3 ; python_version >= '3.7'
+simplejson==3.18.0 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 sniffio==1.3.0 ; python_version >= '3.7'
 snowballstemmer==2.2.0
 soupsieve==2.3.2.post1 ; python_version >= '3.6'
 sqlparse==0.4.3 ; python_version >= '3.5'
-stack-data==0.6.0
-starlette==0.20.4 ; python_version >= '3.7'
+stack-data==0.6.2
+starlette==0.22.0 ; python_version >= '3.7'
 tabulate==0.9.0 ; python_version >= '3.7'
-terminado==0.17.0 ; python_version >= '3.7'
+terminado==0.17.1 ; python_version >= '3.7'
 tinycss2==1.2.1 ; python_version >= '3.7'
 toml==0.10.2 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 tomli==2.0.1 ; python_version >= '3.7'
 tornado==6.2 ; python_version >= '3.7'
 tqdm==4.64.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-traitlets==5.5.0 ; python_version >= '3.7'
-twine==4.0.1
+traitlets==5.7.1 ; python_version >= '3.7'
+twine==4.0.2
 typing-extensions==4.4.0 ; python_version >= '3.7'
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
-uvicorn==0.19.0
+urllib3==1.26.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+uvicorn==0.20.0
 -e .
-virtualenv==20.16.6 ; python_version >= '3.6'
-w3lib==2.0.1 ; python_version >= '3.6'
+virtualenv==20.17.1 ; python_version >= '3.6'
+w3lib==2.1.1 ; python_version >= '3.7'
 wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==1.4.2 ; python_version >= '3.7'
 websockets==10.4 ; python_version >= '3.7'
-widgetsnbextension==4.0.3 ; python_version >= '3.7'
+widgetsnbextension==4.0.4 ; python_version >= '3.7'
 yoyo-migrations==8.1.0
-zipp==3.10.0 ; python_version >= '3.7'
+zipp==3.11.0 ; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,18 +3,18 @@ aiofiles==22.1.0 ; python_version >= '3.7' and python_version < '4.0'
 anyio==3.6.2 ; python_full_version >= '3.6.2'
 appdirs==1.4.4
 appnope==0.1.3 ; sys_platform == 'darwin'
-asttokens==2.1.0
+asttokens==2.2.1
 asyncpg==0.27.0 ; python_full_version >= '3.7.0'
 attrs==22.1.0 ; python_version >= '3.5'
 backcall==0.2.0
 beautifulsoup4==4.11.1 ; python_full_version >= '3.6.0'
 biocommons.seqrepo==0.6.5
 bioutils==0.5.7 ; python_version >= '3.6'
-boto3==1.26.5
-botocore==1.29.5 ; python_version >= '3.7'
+boto3==1.26.28
+botocore==1.29.28 ; python_version >= '3.7'
 bs4==0.0.1
 canonicaljson==1.6.4 ; python_version >= '3.7'
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.12.7 ; python_version >= '3.6'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
 click==8.1.3 ; python_version >= '3.7'
 coloredlogs==15.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -23,32 +23,32 @@ cool-seq-tool==0.1.4
 cssselect==1.2.0 ; python_version >= '3.7'
 decorator==5.1.1 ; python_version >= '3.5'
 executing==1.2.0
-fake-useragent==0.1.14
-fastapi==0.86.0
-ga4gh.vrs[extras]==0.8.7.dev0
-ga4gh.vrsatile.pydantic==0.1.dev3
+fake-useragent==1.1.1
+fastapi==0.88.0
+ga4gh.vrs[extras]==0.8.7.dev1
+ga4gh.vrsatile.pydantic==0.1.dev6
 gene-normalizer==0.2.6
 h11==0.14.0 ; python_version >= '3.7'
-hgvs==1.5.2
+hgvs==1.5.4 ; python_version >= '3.6'
 humanfriendly==10.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 idna==3.4 ; python_version >= '3.5'
-importlib-metadata==5.0.0 ; python_version >= '3.7'
+importlib-metadata==5.1.0 ; python_version >= '3.7'
 inflection==0.5.1 ; python_version >= '3.5'
-ipython==8.6.0 ; python_version >= '3.8'
-jedi==0.18.1 ; python_version >= '3.6'
+ipython==8.7.0 ; python_version >= '3.8'
+jedi==0.18.2 ; python_version >= '3.6'
 jmespath==1.0.1 ; python_version >= '3.7'
 jsonschema==3.2.0
 lxml==4.9.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 markdown==3.4.1 ; python_version >= '3.7'
 matplotlib-inline==0.1.6 ; python_version >= '3.5'
-numpy==1.23.4 ; python_version >= '3.8'
-pandas==1.5.1 ; python_version >= '3.8'
+numpy==1.23.5 ; python_version >= '3.8'
+pandas==1.5.2 ; python_version >= '3.8'
 parse==1.19.0
 parsley==1.3
 parso==0.8.3 ; python_version >= '3.6'
 pexpect==4.8.0 ; sys_platform != 'win32'
 pickleshare==0.7.5
-prompt-toolkit==3.0.32 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.36 ; python_full_version >= '3.6.2'
 psycopg2==2.9.5 ; python_version >= '3.6'
 psycopg2-binary==2.9.5
 ptyprocess==0.7.0
@@ -68,22 +68,22 @@ pyyaml==6.0 ; python_version >= '3.6'
 requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
 requests-html==0.10.0 ; python_full_version >= '3.6.0'
 s3transfer==0.6.0 ; python_version >= '3.7'
-setuptools==65.5.1 ; python_version >= '3.7'
-simplejson==3.17.6 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
+setuptools==65.6.3 ; python_version >= '3.7'
+simplejson==3.18.0 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 sniffio==1.3.0 ; python_version >= '3.7'
 soupsieve==2.3.2.post1 ; python_version >= '3.6'
 sqlparse==0.4.3 ; python_version >= '3.5'
-stack-data==0.6.0
-starlette==0.20.4 ; python_version >= '3.7'
+stack-data==0.6.2
+starlette==0.22.0 ; python_version >= '3.7'
 tabulate==0.9.0 ; python_version >= '3.7'
 tqdm==4.64.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-traitlets==5.5.0 ; python_version >= '3.7'
+traitlets==5.7.1 ; python_version >= '3.7'
 typing-extensions==4.4.0 ; python_version >= '3.7'
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
-uvicorn==0.19.0
-w3lib==2.0.1 ; python_version >= '3.6'
+urllib3==1.26.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+uvicorn==0.20.0
+w3lib==2.1.1 ; python_version >= '3.7'
 wcwidth==0.2.5
 websockets==10.4 ; python_version >= '3.7'
 yoyo-migrations==8.1.0
-zipp==3.10.0 ; python_version >= '3.7'
+zipp==3.11.0 ; python_version >= '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,11 +29,11 @@ install_requires =
     fastapi
     uvicorn
     pydantic
-    ga4gh.vrs[extras] >= 0.8.7dev0
+    ga4gh.vrs[extras] >= 0.8.7dev1
     gene-normalizer >= 0.2.6
     pyliftover
     boto3
-    ga4gh.vrsatile.pydantic >= 0.1.dev3
+    ga4gh.vrsatile.pydantic >= 0.1.dev6
     cool-seq-tool >= 0.1.4
 
 tests_require =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1020,9 +1020,9 @@ def braf_amplification(braf_ncbi_seq_loc, braf_gene_context):
         "id": "normalize.variation:BRAF%20Amplification",
         "type": "VariationDescriptor",
         "variation": {
-            "id": "ga4gh:RCN.avsI73-9i6ykDIRB3eB89jeU1lhyBbYt",
+            "id": "ga4gh:RCN.tXX8oMzsJx3r9ZlqQlzk_K8Luz-bswdT",
             "location": braf_ncbi_seq_loc,
-            "relative_copy_class": "high-level gain",
+            "relative_copy_class": "EFO:0030072",
             "type": "RelativeCopyNumber"
         },
         "molecule_context": "genomic",
@@ -1039,9 +1039,9 @@ def prpf8_amplification(prpf8_ncbi_seq_loc, prpf8_gene_context):
         "id": "normalize.variation:PRPF8%20AMPLIFICATION",
         "type": "VariationDescriptor",
         "variation": {
-            "id": "ga4gh:RCN.w44H1MxQusrCBDxUoLr30E1iJBMGXF14",
+            "id": "ga4gh:RCN.DW0vRfIA0aI4AR0epEh_k-qrB2pdpZVw",
             "location": prpf8_ncbi_seq_loc,
-            "relative_copy_class": "high-level gain",
+            "relative_copy_class": "EFO:0030072",
             "type": "RelativeCopyNumber"
         },
         "molecule_context": "genomic",

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -1,4 +1,6 @@
 """Module for testing HGVS Dup Del mode."""
+from copy import deepcopy
+
 import pytest
 from ga4gh.vrsatile.pydantic.vrsatile_models import VariationDescriptor
 
@@ -318,9 +320,9 @@ def genomic_dup1_vrc(genomic_dup1, genomic_dup1_seq_loc):
     """Create a test fixture for genomic dup relative CNV."""
     genomic_dup1["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.qSnPCsf9ylOaecpSBjTkxWFqxmmyYWtL",
+        "id": "ga4gh:RCN.UBQCyZ7lHIJN6FoQHp3gURfJSWN31S09",
         "location": genomic_dup1_seq_loc,
-        "relative_copy_class": "high-level gain"
+        "relative_copy_class": "EFO:0030072"
     }
     return VariationDescriptor(**genomic_dup1)
 
@@ -585,9 +587,9 @@ def genomic_dup2_vrc(genomic_dup2, genomic_dup2_seq_loc):
     """Create a test fixture for genomic dup relative CNV."""
     genomic_dup2["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.zizBAY460E_wbra9Y6oCxojd8YCbIfnx",
+        "id": "ga4gh:RCN.ClUoNekweei4SUxyjxeLnxagD6vKQ1w7",
         "location": genomic_dup2_seq_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
     return VariationDescriptor(**genomic_dup2)
 
@@ -729,12 +731,11 @@ def genomic_dup3_vac(genomic_dup3, genomic_del3_dup3_loc):
 @pytest.fixture(scope="module")
 def genomic_dup3_vrc(genomic_dup3, genomic_del3_dup3_loc):
     """Create a test fixture for genomic dup relative cnv."""
-    _id = "ga4gh:RCN.4m1TD2538i7v4NQ_OeJ-pIEhlRpYZ3_y"
     genomic_dup3["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.pkRuYZTdIFaA_b9TPc7Czk56VNj1xGz3",
         "location": genomic_del3_dup3_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
     return VariationDescriptor(**genomic_dup3)
 
@@ -784,12 +785,11 @@ def genomic_dup3_free_text_subject():
 @pytest.fixture(scope="module")
 def genomic_dup3_free_text_vrc(genomic_dup3_free_text, genomic_dup3_free_text_subject):
     """Create a test fixture for genomic dup relative cnv."""
-    _id = "ga4gh:RCN.ReWfNwAnchjIPJQEXM038T9M3OsOO7yK"
     genomic_dup3_free_text["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.roF4IsQUR-ZxU_c4KMw9WoDrRnhfA75O",
         "location": genomic_dup3_free_text_subject,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
     return VariationDescriptor(**genomic_dup3_free_text)
 
@@ -839,12 +839,11 @@ def genomic_dup4():
 @pytest.fixture(scope="module")
 def genomic_dup4_vrc(genomic_dup4, genoimc_dup4_loc):
     """Create a test fixture for genomic dup relative cnv."""
-    _id = "ga4gh:RCN.uSGvLYzpzivqDzhuKR44DHc5imZJSmoV"
     genomic_dup4["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.cFmUKSZQQ-CuOqG468ZyP_zF63WflwoF",
         "location": genoimc_dup4_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
     return VariationDescriptor(**genomic_dup4)
 
@@ -907,12 +906,11 @@ def genomic_dup4_free_text_subject():
 @pytest.fixture(scope="module")
 def genomic_dup4_free_text_vrc(genomic_dup4_free_text, genomic_dup4_free_text_subject):
     """Create a test fixture for genomic dup relative cnv."""
-    _id = "ga4gh:RCN.Cf9r8JDpUC18VkkEv44jf8b8WMqUIRFu"
     genomic_dup4_free_text["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.LB5BaDj-GkVlpVAIG9kJSir1uO4DoZ6X",
         "location": genomic_dup4_free_text_subject,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
     return VariationDescriptor(**genomic_dup4_free_text)
 
@@ -972,12 +970,11 @@ def genomic_dup5_abs_cnv(params, genomic_dup5_loc):
 
 def genomic_dup5_rel_cnv(params, genomic_dup5_loc):
     """Create genomic dup4 relative cnv"""
-    _id = "ga4gh:RCN.tr_brFSOfykm3I3ufLQTS9pV8KKjqLhK"
     params["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.1sn-uR3OiG0SbGd-f2IkujiqjcUHzxo3",
         "location": genomic_dup5_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
 
 
@@ -1070,12 +1067,11 @@ def genomic_dup6():
 
 def genomic_dup6_rel_cnv(params, genoimc_dup6_loc):
     """Create genomic dup6 relative cnv"""
-    _id = "ga4gh:RCN.c5Uq3TFDNpQSyDlbXb0BRonw9AYHHk0H"
     params["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.Mb9dPwnAm_KSrifZ0955Lse7Ubr5PaGG",
         "location": genoimc_dup6_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030070"
     }
 
 
@@ -1205,9 +1201,9 @@ def genomic_del1_vrc(genomic_del1, genomic_del1_seq_loc):
     """Create a test fixture for genomic del relative CNV."""
     genomic_del1["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.z7MU8QUSR_aeWG7MP161H4jwPGoyo1No",
+        "id": "ga4gh:RCN.89rlJ6oV422qg04Rhb25rhZJF46LUPqR",
         "location": genomic_del1_seq_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
     return VariationDescriptor(**genomic_del1)
 
@@ -1361,9 +1357,9 @@ def genomic_del2_vrc(genomic_del2, genomic_del2_seq_loc):
     """Create a test fixture for genomic del relative CNV."""
     genomic_del2["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN._19twDngCtP3U-8ED2Kly2HM53I_7CV7",
+        "id": "ga4gh:RCN.Ai0Z31nuQtHGJ-0Vl8ARrblr0xiKW9d-",
         "location": genomic_del2_seq_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
     return VariationDescriptor(**genomic_del2)
 
@@ -1492,12 +1488,11 @@ def genomic_del3():
 @pytest.fixture(scope="module")
 def genomic_del3_vrc(genomic_del3, genomic_del3_dup3_loc):
     """Create a test fixture for genomic del relative cnv."""
-    _id = "ga4gh:RCN.dYerC8FSiqcexo8X1n3XUKpAckoAsfOK"
     genomic_del3["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.OPd0F6EMNNugGkKFBbl4f1We0WwtL9uI",
         "location": genomic_del3_dup3_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030067"
     }
     return VariationDescriptor(**genomic_del3)
 
@@ -1678,12 +1673,11 @@ def genomic_del3_free_text_subject():
 @pytest.fixture(scope="module")
 def genomic_del3_free_text_vrc(genomic_del3_free_text, genomic_del3_free_text_subject):
     """Create a test fixture for genomic del relative cnv."""
-    _id = "ga4gh:RCN.6c0tRlHyFYGSeDEmSyn0nrZJLQDkwVsG"
     genomic_del3_free_text["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.jHNFu709utJ1TkGwQkY1NxmYfRqzof5N",
         "location": genomic_del3_free_text_subject,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030067"
     }
     return VariationDescriptor(**genomic_del3_free_text)
 
@@ -1733,12 +1727,11 @@ def genomic_del4():
 @pytest.fixture(scope="module")
 def genomic_del4_vrc(genomic_del4, genomic_del4_seq_loc):
     """Create a test fixture for genomic del relative cnv."""
-    _id = "ga4gh:RCN.BwZOFAfo5u8TcwbR3DMi8qbIImv96VQU"
     genomic_del4["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.euSDpT11wTt9o9lzlk16lc340OBX2_ij",
         "location": genomic_del4_seq_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030067"
     }
     return VariationDescriptor(**genomic_del4)
 
@@ -1904,12 +1897,11 @@ def genomic_del4_free_text_subject():
 @pytest.fixture(scope="module")
 def genomic_del4_free_text_vrc(genomic_del4_free_text, genomic_del4_free_text_subject):
     """Create a test fixture for genomic del relative cnv."""
-    _id = "ga4gh:RCN.XqfrZ9k9mwDO0cM9duK7ooOih0iR1H2Q"
     genomic_del4_free_text["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.fcVXdxFIjLmULNFOLewLKq9xPvNeVNDm",
         "location": genomic_del4_free_text_subject,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030067"
     }
     return VariationDescriptor(**genomic_del4_free_text)
 
@@ -1949,7 +1941,7 @@ def genomic_uncertain_del_2():
         "id": "normalize.variation:NC_000002.12%3Ag.%28%3F_110104900%29_%28110207160_%3F%29del",  # noqa: E501
         "type": "VariationDescriptor",
         "variation": {
-            "id": "ga4gh:RCN.7EM-Wsg_7mmAE1LW8cmRI3QwKhJCA24a",
+            "id": "ga4gh:RCN.0saHzDrnktHex2tkYyPxQanKwjLUZQu6",
             "location": {
                 "id": "ga4gh:SL.gUeB872FGVaphqoSAfI0gz4KXJvpZKL_",
                 "sequence_id": "ga4gh:SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g",
@@ -1965,7 +1957,7 @@ def genomic_uncertain_del_2():
                 },
                 "type": "SequenceLocation"
             },
-            "relative_copy_class": "partial loss",
+            "relative_copy_class": "EFO:0030067",
             "type": "RelativeCopyNumber"
         },
         "molecule_context": "genomic",
@@ -1981,7 +1973,7 @@ def genomic_uncertain_del_y():
         "id": "normalize.variation:NC_000024.10%3Ag.%28%3F_14076802%29_%2857165209_%3F%29del",  # noqa: E501
         "type": "VariationDescriptor",
         "variation": {
-            "id": "ga4gh:RCN.2q7DKevv8nUh87Sl00Z7l50h047Ti2at",
+            "id": "ga4gh:RCN.7Nl4T845v9vuVS4PUB8HI4-tLPsEWU6e",
             "location": {
                 "id": "ga4gh:SL.ykRzA8IFueiCG7oznnN4teL2nXXBshHV",
                 "sequence_id": "ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -1997,7 +1989,7 @@ def genomic_uncertain_del_y():
                 },
                 "type": "SequenceLocation"
             },
-            "relative_copy_class": "partial loss",
+            "relative_copy_class": "EFO:0030067",
             "type": "RelativeCopyNumber"
         },
         "molecule_context": "genomic",
@@ -2033,12 +2025,11 @@ def genomic_del5_abs_cnv(params, genomic_del5_seq_loc):
 
 def genomic_del5_rel_cnv(params, genomic_del5_seq_loc):
     """Create genomic del5 relative cnv"""
-    _id = "ga4gh:RCN.9rG3a5u3JODwQGVrv1IgAjG6SZgdvraH"
     params["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.P0LWls1SeRF881B-uhomC8B4BHc6Fo2R",
         "location": genomic_del5_seq_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -2247,12 +2238,11 @@ def genomic_del6():
 
 def genomic_del6_rel_cnv(params, genomic_del6_seq_loc):
     """Create genomic del6 relative cnv"""
-    _id = "ga4gh:RCN.zsagK87b_RdK4_QZGMnbNl39LCuJUjAr"
     params["variation"] = {
         "type": "RelativeCopyNumber",
-        "id": _id,
+        "id": "ga4gh:RCN.gQwVlnomQRAffyySAQdj3PYxnEalHrXK",
         "location": genomic_del6_seq_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -2483,7 +2473,7 @@ async def test_genomic_dup1(test_handler, genomic_dup1_lse,
     assertion_checks(resp.variation_descriptor, genomic_dup1_vac, q)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="high-level gain")
+                                        relative_copy_class="EFO:0030072")
     assertion_checks(resp.variation_descriptor, genomic_dup1_vrc, q)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr")
@@ -2503,7 +2493,7 @@ async def test_genomic_dup1(test_handler, genomic_dup1_lse,
     assertion_checks(resp.variation_descriptor, genomic_dup1_vac, q, ignore_id=True)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="high-level gain")
+                                        relative_copy_class="EFO:0030072")
     assertion_checks(resp.variation_descriptor, genomic_dup1_vrc, q, ignore_id=True)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr")
@@ -2628,8 +2618,11 @@ async def test_genomic_dup3(test_handler, genomic_dup3_vrc, genomic_dup3_vac,
     assertion_checks(resp.variation_descriptor, genomic_dup3_vac, q)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="low-level gain")
-    assertion_checks(resp.variation_descriptor, genomic_dup3_vrc, q)
+                                        relative_copy_class="EFO:0030071")
+    test_var = deepcopy(genomic_dup3_vrc)
+    test_var.variation.relative_copy_class = "EFO:0030071"
+    test_var.variation.id = "ga4gh:RCN.lR7qHx5BeS4yJlaopO8JteBq1AO3Kv9m"
+    assertion_checks(resp.variation_descriptor, test_var, q)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr",
                                         untranslatable_returns_text=True)
@@ -2941,7 +2934,7 @@ async def test_genomic_del1(test_handler, genomic_del1_lse, genomic_del1_vac,
     assertion_checks(resp.variation_descriptor, genomic_del1_vac, q)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="copy neutral")
+                                        relative_copy_class="EFO:0030067")
     assertion_checks(resp.variation_descriptor, genomic_del1_vrc, q)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr")
@@ -2958,7 +2951,7 @@ async def test_genomic_del1(test_handler, genomic_del1_lse, genomic_del1_vac,
     assertion_checks(resp.variation_descriptor, genomic_del1_vac, q, ignore_id=True)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="copy neutral")
+                                        relative_copy_class="EFO:0030067")
     assertion_checks(resp.variation_descriptor, genomic_del1_vrc, q, ignore_id=True)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr")
@@ -3026,7 +3019,7 @@ async def test_genomic_del2(test_handler, genomic_del2_lse, genomic_del2_vac,
     assertion_checks(resp.variation_descriptor, genomic_del2_vac, q)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="complete loss")
+                                        relative_copy_class="EFO:0030069")
     assertion_checks(resp.variation_descriptor, genomic_del2_vrc, q)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr")
@@ -3043,7 +3036,7 @@ async def test_genomic_del2(test_handler, genomic_del2_lse, genomic_del2_vac,
     assertion_checks(resp.variation_descriptor, genomic_del2_vac, q, ignore_id=True)
 
     resp = await test_handler.normalize(q, "relative_cnv",
-                                        relative_copy_class="complete loss")
+                                        relative_copy_class="EFO:0030069")
     assertion_checks(resp.variation_descriptor, genomic_del2_vrc, q, ignore_id=True)
 
     resp = await test_handler.normalize(q, "repeated_seq_expr")

--- a/tests/test_to_canonical_variation.py
+++ b/tests/test_to_canonical_variation.py
@@ -28,7 +28,7 @@ def variation1_seq_loc():
 def variation1_lse(variation1_seq_loc):
     """Create test fixture for NC_000013.11:20189346:GGG:GG"""
     params = {
-        "id": "ga4gh:CLV.tg0nG9q1DMP_J-vcWiaASPW44GMEh47k",
+        "id": "ga4gh:CAN.tg0nG9q1DMP_J-vcWiaASPW44GMEh47k",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:VA.jkAILAe4dK4tQ3y2hz-GHtZRAnbVC__T",
@@ -47,7 +47,7 @@ def variation1_lse(variation1_seq_loc):
 def variation_del_lse():
     """Create test fixture for NC_000013.11:20003096:C:"""
     params = {
-        "id": "ga4gh:CLV.6_wBT_bhV-hwjaqDxq3kEs3nyILkF4du",
+        "id": "ga4gh:CAN.6_wBT_bhV-hwjaqDxq3kEs3nyILkF4du",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:VA.l55oQYOlWUoYwAxb4trpbqmMNaknTa1U",
@@ -72,7 +72,7 @@ def variation_del_lse():
 def variation1_abs_cnv(variation1_seq_loc):
     """Create test fixture for variation1 represented as absolute cnv"""
     params = {
-        "id": "ga4gh:CLV.hQ2OOqFOxd_bdXJbZx4-AwJgvQcPZeLq",
+        "id": "ga4gh:CAN.hQ2OOqFOxd_bdXJbZx4-AwJgvQcPZeLq",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:ACN.p_KPDMw49gN0frUAlt_FRBN7Ls4vToZu",
@@ -88,13 +88,13 @@ def variation1_abs_cnv(variation1_seq_loc):
 def variation1_rel_cnv(variation1_seq_loc):
     """Create test fixture for variation1 represented as relative cnv"""
     params = {
-        "id": "ga4gh:CLV.Ue8qumkG57LEqjS2_xXeW9PVDuKDKdd0",
+        "id": "ga4gh:CAN.YIYLpl8tuoDp9ckZ-1f1QQJ5q0-i3q-J",
         "type": "CanonicalVariation",
         "canonical_context": {
-            "id": "ga4gh:RCN.FEoHs6XOuAI0Lx5mJfKN4LF4iLpmeJZu",
+            "id": "ga4gh:RCN.0DNPg6rTfM6GLGrUSF_pLl3VM_3sQl2z",
             "type": "RelativeCopyNumber",
             "location": variation1_seq_loc,
-            "relative_copy_class": "complete loss"
+            "relative_copy_class": "EFO:0030069"
         }
     }
     return CanonicalVariation(**params)
@@ -104,7 +104,7 @@ def variation1_rel_cnv(variation1_seq_loc):
 def variation1_rse(variation1_seq_loc):
     """Create test fixture for variation1 represented as RSE"""
     params = {
-        "id": "ga4gh:CLV.oizMWSwBdIddFvs_vA8YqxR7YWupBMrF",
+        "id": "ga4gh:CAN.oizMWSwBdIddFvs_vA8YqxR7YWupBMrF",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:VA.91WFk_XWzbzUEI-SfYZip8r1g7I5wqBo",
@@ -131,7 +131,7 @@ def variation1_rse(variation1_seq_loc):
 def variation2(braf_v600e_genomic_sub):
     """Create test fixture for NC_000007.14:140753335:A:T"""
     params = {
-        "id": "ga4gh:CLV.dP6z4p7SoGJFmlFQcjOQo2d1mXuo1QiY",
+        "id": "ga4gh:CAN.dP6z4p7SoGJFmlFQcjOQo2d1mXuo1QiY",
         "type": "CanonicalVariation",
         "canonical_context": braf_v600e_genomic_sub
     }
@@ -142,7 +142,7 @@ def variation2(braf_v600e_genomic_sub):
 def variation3_lse(grch38_genomic_insertion_variation):
     """Create test fixture for NC_000017.10:g.37880993_37880994insGCTTACGTGATG"""
     params = {
-        "id": "ga4gh:CLV.8Pi46FGQsmKIb-6Q0NYKQh0baDBOMvFF",
+        "id": "ga4gh:CAN.8Pi46FGQsmKIb-6Q0NYKQh0baDBOMvFF",
         "type": "CanonicalVariation",
         "canonical_context": grch38_genomic_insertion_variation
     }
@@ -153,7 +153,7 @@ def variation3_lse(grch38_genomic_insertion_variation):
 def variation3_abs_cnv(grch38_genomic_insertion_seq_loc):
     """Create test fixture for variation3 represented as absolute cnv"""
     params = {
-        "id": "ga4gh:CLV.DzOrKfPgfowNyivzu3WP48H8iPFiLdd1",
+        "id": "ga4gh:CAN.DzOrKfPgfowNyivzu3WP48H8iPFiLdd1",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:ACN.e_Nd4RGisOcOmrWVklM-3gGZIo6jSnml",
@@ -169,13 +169,13 @@ def variation3_abs_cnv(grch38_genomic_insertion_seq_loc):
 def variation3_rel_cnv(grch38_genomic_insertion_seq_loc):
     """Create test fixture for variation3 represented as relative cnv"""
     params = {
-        "id": "ga4gh:CLV.3VhMDipw7_25RSuPvtz-DCYhzjQCoED7",
+        "id": "ga4gh:CAN.wdQ6AQqEUxX9cV7rImNqOMq6r_freYfZ",
         "type": "CanonicalVariation",
         "canonical_context": {
-            "id": "ga4gh:RCN.XOeH_PqiR6pkFMmHewn9SjxZEOOZoXVp",
+            "id": "ga4gh:RCN.A9ykWRgv47k6MJx8aNQLfn0-LyTlPliO",
             "type": "RelativeCopyNumber",
             "location": grch38_genomic_insertion_seq_loc,
-            "relative_copy_class": "high-level gain"
+            "relative_copy_class": "EFO:0030072"
         }
     }
     return CanonicalVariation(**params)
@@ -185,7 +185,7 @@ def variation3_rel_cnv(grch38_genomic_insertion_seq_loc):
 def variation3_rse(grch38_genomic_insertion_seq_loc):
     """Create test fixture for variation3 represented as RSE"""
     params = {
-        "id": "ga4gh:CLV.Ohalqu5SLmNmwjaE00v26KskGfggXwjq",
+        "id": "ga4gh:CAN.Ohalqu5SLmNmwjaE00v26KskGfggXwjq",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:VA.j6BnT9kvqTO_BQCjTsOzhcnjiwNlhMHv",
@@ -212,7 +212,7 @@ def variation3_rse(grch38_genomic_insertion_seq_loc):
 def variation4():
     """Create test fixture for NC_000001.11:g.2229202_2229203insCTC"""
     params = {
-        "id": "ga4gh:CLV.azUwFImJO4pTH6rSRx6UItCoxJcTvxln",
+        "id": "ga4gh:CAN.azUwFImJO4pTH6rSRx6UItCoxJcTvxln",
         "type": "CanonicalVariation",
         "canonical_context": {
             "id": "ga4gh:VA.M9Ekcss52lqr1IoX3wZeLTxVsrPW1MSq",
@@ -288,7 +288,7 @@ async def test_to_canonical_variation_deletion(
 
     resp = await test_handler.to_canonical_variation(
         q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="relative_cnv",
-        relative_copy_class="complete loss")
+        relative_copy_class="EFO:0030069")
     assert resp.canonical_variation == variation1_rel_cnv
     assert resp.warnings == []
 
@@ -384,7 +384,7 @@ async def test_to_canonical_variation_duplication(
 
     resp = await test_handler.to_canonical_variation(
         q, fmt="hgvs", do_liftover=True, hgvs_dup_del_mode="relative_cnv",
-        relative_copy_class="high-level gain")
+        relative_copy_class="EFO:0030072")
     assert resp.canonical_variation == variation3_rel_cnv
     assert resp.warnings == []
 

--- a/tests/to_copy_number_variation/test_amplification_to_rel_cnv.py
+++ b/tests/to_copy_number_variation/test_amplification_to_rel_cnv.py
@@ -7,8 +7,8 @@ def kit_amplification():
     """Create test fixture for KIT amplification"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.bLLqdZZ_t8SbF1Ay6bws-HpuJqbOvtCs",
-        "relative_copy_class": "high-level gain",
+        "id": "ga4gh:RCN.B25HjtfWQuCtYyeiiVKRy0rHQm7GNOVX",
+        "relative_copy_class": "EFO:0030072",
         "location": {
             "type": "SequenceLocation",
             "id": "ga4gh:SL.7SSzl2VSAZyrt_GrMAQlIJuuegXS7KA5",

--- a/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
@@ -9,9 +9,9 @@ def genomic_dup1_rel_38(genomic_dup1_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN._1Nz0yj2g9Q6cRO8j6oRi5peUJYjTAga",
+        "id": "ga4gh:RCN.erAJfClNaRMtgJ6ZPzresRJaKdiSGhNr",
         "location": genomic_dup1_seq_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
 
 
@@ -43,9 +43,9 @@ def genomic_dup1_rel_37(genomic_dup1_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.dfqRkwlXaJqc8ZtG5mORZU4Cdsp3DTcz",
+        "id": "ga4gh:RCN.wSv8wmG69FZKMK-PO3MoS1j-sUUfF6CH",
         "location": genomic_dup1_37_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
 
 
@@ -54,9 +54,9 @@ def genomic_dup2_rel_38(genomic_dup2_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.U9sPvq7Ggxf3jzcJlTD_53dAaesWZ6-o",
+        "id": "ga4gh:RCN.fB4IGlSyBw6q70NwdCiHm2tQlSvM2fB6",
         "location": genomic_dup2_seq_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030068"
     }
 
 
@@ -88,9 +88,9 @@ def genomic_dup2_rel_37(genomic_dup2_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.BmS2zuzMCgnrbgU5zZgqwaPEBCGV6Wxo",
+        "id": "ga4gh:RCN.jzaEHj_5CYAd0wSrIygdhZViFH3lhcii",
         "location": genomic_dup2_37_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030068"
     }
 
 
@@ -110,9 +110,9 @@ def genomic_dup3_rel_38(genomic_del3_dup3_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.FoK9bxEWUcnG6yb4MQwuEOKnyvmJQHWQ",
+        "id": "ga4gh:RCN.zn-lzk4_0ijOoPr4cSIB7aX9XySZD91a",
         "location": genomic_del3_dup3_loc,
-        "relative_copy_class": "high-level gain"
+        "relative_copy_class": "EFO:0030072"
     }
 
 
@@ -144,9 +144,9 @@ def genomic_dup3_rel_37(genomic_dup3_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.oBHqFRckDEI_Z5urrQ_oexexObWv39FS",
+        "id": "ga4gh:RCN.aXMmX6vH8bdQpBi_YwlqIfXvpnZVCIzc",
         "location": genomic_dup3_37_loc,
-        "relative_copy_class": "high-level gain"
+        "relative_copy_class": "EFO:0030072"
     }
 
 
@@ -166,9 +166,9 @@ def genomic_dup4_rel_38(genoimc_dup4_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.4aCUMyIGHAaqGLGnWdGF3pU81nMPiRMf",
+        "id": "ga4gh:RCN.R84TneS5Lo52LXV1QvBTC-VHCNbTmbuG",
         "location": genoimc_dup4_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
 
 
@@ -200,9 +200,9 @@ def genomic_dup4_rel_37(genomic_dup4_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.U5eCTbzeX2JOyWFfQ9xOYacjbBKcz4lM",
+        "id": "ga4gh:RCN.PqgGxKRXyLsyTnuDFfjXdy6WOS92Xvhd",
         "location": genomic_dup4_37_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
 
 
@@ -222,9 +222,9 @@ def genomic_dup5_rel_38(genomic_dup5_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.y4ia336ms3p6s51U36K5-kkXeW9PFXMz",
+        "id": "ga4gh:RCN.1sQgwjUh4hWLa8AQ6kH4eXAurJnJSkZr",
         "location": genomic_dup5_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030068"
     }
 
 
@@ -256,9 +256,9 @@ def genomic_dup5_rel_37(genomic_dup5_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.AQqRwFtHFlvZG9Lcl28flKTITe_9wR3Z",
+        "id": "ga4gh:RCN.eDwyniE1UOiei4d5Wr92yMeAJRdx7iR8",
         "location": genomic_dup5_37_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030068"
     }
 
 
@@ -278,9 +278,9 @@ def genomic_dup6_rel_38(genoimc_dup6_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.popti3moTOvPqsqPopElu7-TqgINIq6I",
+        "id": "ga4gh:RCN.D3sNrwDztEGdbHArugYZOKz4XSBTEHYg",
         "location": genoimc_dup6_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -312,9 +312,9 @@ def genomic_dup6_rel_37(genomic_dup6_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.Lvhuup_Md0tsrN6eqO5kV3sUO4vRtMsW",
+        "id": "ga4gh:RCN.zixYHRqtbfeHVj5QLVhWmxFFVImrlvB-",
         "location": genomic_dup6_37_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -323,9 +323,9 @@ def genomic_del1_rel_38(genomic_del1_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.z7MU8QUSR_aeWG7MP161H4jwPGoyo1No",
+        "id": "ga4gh:RCN.89rlJ6oV422qg04Rhb25rhZJF46LUPqR",
         "location": genomic_del1_seq_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -357,9 +357,9 @@ def genomic_del1_rel_37(genomic_del1_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.bT-NgstX8QjwhOR3FMbQmfXozLQ9wdHB",
+        "id": "ga4gh:RCN.K2fiI9tIcmUkB4QICqvxNQuWiueRLF2t",
         "location": genomic_del1_37_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -368,9 +368,9 @@ def genomic_del2_rel_38(genomic_del2_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.xXa8l2bXplY26DKNBDTttUUc0aN1Pwpo",
+        "id": "ga4gh:RCN.4dy3yka2_hd_8S_TEnJ9BxQB3AvP3kkK",
         "location": genomic_del2_seq_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030071"
     }
 
 
@@ -402,9 +402,9 @@ def genomic_del2_rel_37(genomic_del2_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.Kw5y22t_9O3R_DBfP43ZgXkuLtrjbK2e",
+        "id": "ga4gh:RCN.Yhu2MHBFqzBlgyw7nc84fgSfEez6DUQG",
         "location": genomic_del2_37_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030071"
     }
 
 
@@ -424,9 +424,9 @@ def genomic_del3_rel_38(genomic_del3_dup3_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.RoVV-V_2zSMFA8IUJSs3Ah8Y-3jh6ktV",
+        "id": "ga4gh:RCN.l0fNhTdZcTwNkEan8gViP1dK2d3DQmTn",
         "location": genomic_del3_dup3_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
 
 
@@ -458,9 +458,9 @@ def genomic_del3_rel_37(genomic_del3_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.rKupZ9FRkAXrYtZmaMd_7RF6vU4fOxLS",
+        "id": "ga4gh:RCN.01hSqtbuhzMI2uSd7bdKN34vWI1gQpCc",
         "location": genomic_del3_37_loc,
-        "relative_copy_class": "complete loss"
+        "relative_copy_class": "EFO:0030069"
     }
 
 
@@ -480,9 +480,9 @@ def genomic_del4_rel_38(genomic_del4_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.BwZOFAfo5u8TcwbR3DMi8qbIImv96VQU",
+        "id": "ga4gh:RCN.Tgjw-QKM3gbgXROH2OX4WqiSNVXr6zn-",
         "location": genomic_del4_seq_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030068"
     }
 
 
@@ -514,9 +514,9 @@ def genomic_del4_rel_37(genomic_del4_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.xeNugTAGZ5HPU5hyoOa6Jk_lzQKFj-2S",
+        "id": "ga4gh:RCN.GLYkGWKznmABnCVcImNuwRNvxBt3Txrc",
         "location": genomic_del4_37_loc,
-        "relative_copy_class": "partial loss"
+        "relative_copy_class": "EFO:0030068"
     }
 
 
@@ -536,9 +536,9 @@ def genomic_del5_rel_38(genomic_del5_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.y5LOigojbNT1BqtAv9BsKQ7-2i-iL8jA",
+        "id": "ga4gh:RCN.P0LWls1SeRF881B-uhomC8B4BHc6Fo2R",
         "location": genomic_del5_seq_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -570,9 +570,9 @@ def genomic_del5_rel_37(genomic_del5_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.jExtRl5UIhAlKPw68TtcA05-Gfi6cXQZ",
+        "id": "ga4gh:RCN.G_CYcPca9J4V1w1C6T4mdShdgSsAPhyp",
         "location": genomic_del5_37_loc,
-        "relative_copy_class": "copy neutral"
+        "relative_copy_class": "EFO:0030067"
     }
 
 
@@ -592,9 +592,9 @@ def genomic_del6_rel_38(genomic_del6_seq_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.nmDpVRjFPJZF4K-HxmIgcAewOKtCOfGC",
+        "id": "ga4gh:RCN.113rZRmZgUMR61kPvn0IaLrhQvd5K_ox",
         "location": genomic_del6_seq_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030071"
     }
 
 
@@ -626,9 +626,9 @@ def genomic_del6_rel_37(genomic_del6_37_loc):
     """Create test fixture relative copy number variation"""
     return {
         "type": "RelativeCopyNumber",
-        "id": "ga4gh:RCN.C597L06IPEjWaoP-ktRkPxbbayBWBg12",
+        "id": "ga4gh:RCN.W-sFtBYitL5YSfGjqN5XnHjglqf9y91d",
         "location": genomic_del6_37_loc,
-        "relative_copy_class": "low-level gain"
+        "relative_copy_class": "EFO:0030071"
     }
 
 
@@ -664,16 +664,16 @@ async def test_genomic_dup1_relative_cnv(test_cnv_handler, genomic_dup1_rel_38,
     """Test that genomic duplication works correctly"""
     q = "NC_000003.12:g.49531262dup"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030069", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup1_rel_38
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030069", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup1_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=True)
+        q, relative_copy_class="EFO:0030069", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup1_rel_38
 
 
@@ -709,16 +709,16 @@ async def test_genomic_dup2_relative_cnv(test_cnv_handler, genomic_dup2_rel_38,
     """Test that genomic duplication works correctly"""
     q = "NC_000016.10:g.2087938_2087948dup"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030068", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup2_rel_38
 
     q = "NC_000016.9:g.2137939_2137949dup"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030068", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup2_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=True)
+        q, relative_copy_class="EFO:0030068", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup2_rel_38
 
 
@@ -754,16 +754,16 @@ async def test_genomic_dup3_relative_cnv(test_cnv_handler, genomic_dup3_rel_38,
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="high-level gain", do_liftover=False)
+        q, relative_copy_class="EFO:0030072", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup3_rel_38
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="high-level gain", do_liftover=False)
+        q, relative_copy_class="EFO:0030072", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup3_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="high-level gain", do_liftover=True)
+        q, relative_copy_class="EFO:0030072", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup3_rel_38
 
 
@@ -799,16 +799,16 @@ async def test_genomic_dup4_relative_cnv(test_cnv_handler, genomic_dup4_rel_38,
     """Test that genomic duplication works correctly"""
     q = "NC_000020.11:g.(?_30417576)_(31394018_?)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030069", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup4_rel_38
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030069", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup4_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=True)
+        q, relative_copy_class="EFO:0030069", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup4_rel_38
 
 
@@ -844,16 +844,16 @@ async def test_genomic_dup5_relative_cnv(test_cnv_handler, genomic_dup5_rel_38,
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(?_154021812)_154092209dup"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030068", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup5_rel_38
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030068", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup5_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=True)
+        q, relative_copy_class="EFO:0030068", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup5_rel_38
 
 
@@ -889,16 +889,16 @@ async def test_genomic_dup6_relative_cnv(test_cnv_handler, genomic_dup6_rel_38,
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.154021812_(154092209_?)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=False)
+        q, relative_copy_class="EFO:0030067", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup6_rel_38
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=False)
+        q, relative_copy_class="EFO:0030067", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup6_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=True)
+        q, relative_copy_class="EFO:0030067", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_dup6_rel_38
 
 
@@ -934,16 +934,16 @@ async def test_genomic_del1_relative_cnv(test_cnv_handler, genomic_del1_rel_38,
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10149811del"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=False)
+        q, relative_copy_class="EFO:0030067", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del1_rel_38
 
     q = "NC_000003.11:g.10191495del"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=False)
+        q, relative_copy_class="EFO:0030067", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del1_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=True)
+        q, relative_copy_class="EFO:0030067", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del1_rel_38
 
 
@@ -979,16 +979,16 @@ async def test_genomic_del2_relative_cnv(test_cnv_handler, genomic_del2_rel_38,
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10146595_10146613del"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=False)
+        q, relative_copy_class="EFO:0030071", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del2_rel_38
 
     q = "NC_000003.11:g.10188279_10188297del"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=False)
+        q, relative_copy_class="EFO:0030071", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del2_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=True)
+        q, relative_copy_class="EFO:0030071", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del2_rel_38
 
 
@@ -1024,16 +1024,16 @@ async def test_genomic_del3_relative_cnv(test_cnv_handler, genomic_del3_rel_38,
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)del"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030069", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del3_rel_38
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030069", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del3_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="complete loss", do_liftover=True)
+        q, relative_copy_class="EFO:0030069", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del3_rel_38
 
 
@@ -1069,16 +1069,16 @@ async def test_genomic_del4_relative_cnv(test_cnv_handler, genomic_del4_rel_38,
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_31120496)_(33339477_?)del"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030068", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del4_rel_38
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=False)
+        q, relative_copy_class="EFO:0030068", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del4_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="partial loss", do_liftover=True)
+        q, relative_copy_class="EFO:0030068", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del4_rel_38
 
 
@@ -1114,16 +1114,16 @@ async def test_genomic_del5_relative_cnv(test_cnv_handler, genomic_del5_rel_38,
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_18575354)_18653629del"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=False)
+        q, relative_copy_class="EFO:0030067", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del5_rel_38
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=False)
+        q, relative_copy_class="EFO:0030067", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del5_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="copy neutral", do_liftover=True)
+        q, relative_copy_class="EFO:0030067", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del5_rel_38
 
 
@@ -1159,16 +1159,16 @@ async def test_genomic_del6_relative_cnv(test_cnv_handler, genomic_del6_rel_38,
     """Test that genomic deletion works correctly"""
     q = "NC_000006.12:g.133462764_(133464858_?)del"  # 38
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=False)
+        q, relative_copy_class="EFO:0030071", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del6_rel_38
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=False)
+        q, relative_copy_class="EFO:0030071", do_liftover=False)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del6_rel_37
 
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=True)
+        q, relative_copy_class="EFO:0030071", do_liftover=True)
     assert resp.relative_copy_number.dict(by_alias=True) == genomic_del6_rel_38
 
 
@@ -1179,8 +1179,9 @@ async def test_invalid_cnv_parameters(test_cnv_handler):
     resp, w = await test_cnv_handler.hgvs_to_relative_copy_number(
         q, relative_copy_class="low-level gains", do_liftover=True)
     assert resp is None
-    assert w == ["low-level gains is not a valid relative copy class: ['complete loss', "  # noqa: E501
-                 "'partial loss', 'copy neutral', 'low-level gain', 'high-level gain']"]
+    assert w == ["low-level gains is not a valid relative copy class: ['EFO:0030070', "
+                 "'EFO:0030072', 'EFO:0030071', 'EFO:0030067', 'EFO:0030069', "
+                 "'EFO:0030068']"]
 
 
 @pytest.mark.asyncio
@@ -1188,7 +1189,7 @@ async def test_invalid_cnv(test_cnv_handler):
     """Check that invalid input return warnings"""
     q = "DAG1 g.49568695dup"
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=True,
+        q, relative_copy_class="EFO:0030071", do_liftover=True,
         untranslatable_returns_text=True)
     assert set(resp.warnings) == {"Unable to translate DAG1 g.49568695dup to copy number variation",  # noqa: E501
                                   "DAG1 g.49568695dup is not a supported HGVS genomic duplication or deletion"}  # noqa: E501
@@ -1196,7 +1197,7 @@ async def test_invalid_cnv(test_cnv_handler):
 
     q = "braf v600e"
     resp = await test_cnv_handler.hgvs_to_relative_copy_number(
-        q, relative_copy_class="low-level gain", do_liftover=True)
+        q, relative_copy_class="EFO:0030071", do_liftover=True)
     assert set(resp.warnings) == {"Unable to translate braf v600e to copy number variation",  # noqa: E501
                                   "braf v600e is not a supported HGVS genomic duplication or deletion"}  # noqa: E501
     assert resp.relative_copy_number is None

--- a/variation/hgvs_dup_del_mode.py
+++ b/variation/hgvs_dup_del_mode.py
@@ -5,8 +5,8 @@ from typing import Optional, Dict, Tuple, List
 from ga4gh.vrs import models
 from ga4gh.core import ga4gh_identify
 from cool_seq_tool.data_sources import SeqRepoAccess
+from ga4gh.vrsatile.pydantic.vrs_models import RelativeCopyClass
 
-from variation.schemas.hgvs_to_copy_number_schema import RelativeCopyClass
 from variation.schemas.normalize_response_schema\
     import HGVSDupDelMode as HGVSDupDelModeEnum
 
@@ -55,7 +55,8 @@ class HGVSDupDelMode:
         """Use default characteristics to return a variation.
         If baseline_copies not provided and endpoints are ambiguous: relative_cnv
             if relative_copy_class not provided:
-                relative_copy_class = `partial loss` if del, `low-level gain` if dup
+                relative_copy_class = `EFO:0030067` (copy number loss) if del,
+                    `EFO:0030070` (copy number gain) if dup
         elif baseline_copies provided: absolute_cnv
             copies are baseline + 1 for dup, baseline - 1 for del
         elif len del or dup > 100bp (use outermost coordinates):
@@ -121,9 +122,9 @@ class HGVSDupDelMode:
         """
         if not relative_copy_class:
             if del_or_dup == "del":
-                relative_copy_class = RelativeCopyClass.PARTIAL_LOSS.value
+                relative_copy_class = RelativeCopyClass.COPY_NUMBER_LOSS.value
             else:
-                relative_copy_class = RelativeCopyClass.LOW_LEVEL_GAIN.value
+                relative_copy_class = RelativeCopyClass.COPY_NUMBER_GAIN.value
         variation = {
             "type": "RelativeCopyNumber",
             "location": location,

--- a/variation/schemas/hgvs_to_copy_number_schema.py
+++ b/variation/schemas/hgvs_to_copy_number_schema.py
@@ -89,7 +89,7 @@ class HgvsToRelativeCopyNumberService(ServiceResponse):
                         "start": {"type": "Number", "value": 49531260},
                         "end": {"type": "Number", "value": 49531262}
                     },
-                    "relative_copy_class": "complete loss"
+                    "relative_copy_class": "EFO:0030069"
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",

--- a/variation/schemas/normalize_response_schema.py
+++ b/variation/schemas/normalize_response_schema.py
@@ -254,7 +254,7 @@ class ToCanonicalVariationService(ServiceResponse):
                 "query": "NC_000007.14:140753335:A:T",
                 "warnings": [],
                 "canonical_variation": {
-                    "id": "ga4gh:CLV.dP6z4p7SoGJFmlFQcjOQo2d1mXuo1QiY",
+                    "id": "ga4gh:CAN.dP6z4p7SoGJFmlFQcjOQo2d1mXuo1QiY",
                     "type": "CanonicalVariation",
                     "canonical_context": {
                         "id": "ga4gh:VA.3xFHF399HGbG1JUf5uwcj3oWVKZJ70oX",

--- a/variation/schemas/service_schema.py
+++ b/variation/schemas/service_schema.py
@@ -133,7 +133,7 @@ class AmplificationToRelCnvService(ServiceResponse):
                         "start": {"type": "Number", "value": 140713327},
                         "end": {"type": "Number", "value": 140924929}
                     },
-                    "relative_copy_class": "high-level gain"
+                    "relative_copy_class": "EFO:0030072"
                 },
                 "service_meta_": {
                     "version": "0.7.dev0",

--- a/variation/to_canonical_variation.py
+++ b/variation/to_canonical_variation.py
@@ -256,7 +256,7 @@ class ToCanonicalVariation(ToVRS):
 
         if hgvs_dup_del_mode == HGVSDupDelModeEnum.RELATIVE_CNV:
             if relative_copy_class:
-                if relative_copy_class.lower() not in VALID_RELATIVE_COPY_CLASS:
+                if relative_copy_class.upper() not in VALID_RELATIVE_COPY_CLASS:
                     return None, [f"{relative_copy_class} is not a valid relative "
                                   f"copy class: {VALID_RELATIVE_COPY_CLASS}"]
         elif hgvs_dup_del_mode == HGVSDupDelModeEnum.ABSOLUTE_CNV:

--- a/variation/to_copy_number_variation.py
+++ b/variation/to_copy_number_variation.py
@@ -152,7 +152,7 @@ class ToCopyNumberVariation(ToVRS):
         :return: HgvsToRelativeCopyNumberService containing Relative Copy Number
             Variation and warnings
         """
-        if relative_copy_class and relative_copy_class.lower() not in VALID_RELATIVE_COPY_CLASS:  # noqa: E501
+        if relative_copy_class and relative_copy_class.upper() not in VALID_RELATIVE_COPY_CLASS:  # noqa: E501
             return None, [f"{relative_copy_class} is not a valid relative copy class: "
                           f"{VALID_RELATIVE_COPY_CLASS}"]
 
@@ -371,7 +371,7 @@ class ToCopyNumberVariation(ToVRS):
                     vrs_location.id = ga4gh_identify(vrs_location)
                     vrs_rcn = models.RelativeCopyNumber(
                         location=vrs_location,
-                        relative_copy_class=RelativeCopyClass.HIGH_LEVEL_GAIN.value)
+                        relative_copy_class=RelativeCopyClass.HIGH_LEVEL_COPY_NUMBER_GAIN.value)  # noqa: E501
                     vrs_rcn.id = ga4gh_identify(vrs_rcn)
                     variation = RelativeCopyNumber(**vrs_rcn.as_dict())
             else:

--- a/variation/validators/amplification.py
+++ b/variation/validators/amplification.py
@@ -61,8 +61,9 @@ class Amplification(Validator):
                 seq_loc = get_priority_sequence_location(
                     gene_descriptor, self.seqrepo_access)
                 if seq_loc:
-                    rcn = self.vrs.to_rel_cnv(models.SequenceLocation(**seq_loc),
-                                              RelativeCopyClass.HIGH_LEVEL_GAIN)
+                    rcn = self.vrs.to_rel_cnv(
+                        models.SequenceLocation(**seq_loc),
+                        RelativeCopyClass.HIGH_LEVEL_COPY_NUMBER_GAIN)
                 else:
                     errors.append(f"No SequenceLocation found for gene: {gene}")
             else:

--- a/variation/version.py
+++ b/variation/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.dev2"
+__version__ = "0.7.dev3"


### PR DESCRIPTION
Close #344

- Default hgvs dup del mode if relative_copy_class not provided, uses `EFO:0030067` (copy number loss) if deletion or `EFO:0030070` (copy number gain) if duplication
- For tests:
    - (If using default characteristics, use above IDs)
    `complete loss` → `EFO:0030069`
    `partial loss` →  `EFO:0030068`
    `copy neutral` → `EFO:0030067`
    `low-level gain` → `EFO:0030071`
    `high-level gain` → `EFO:0030072`
- I guess the prefix for `CanonicalVariation` also changed: `CLV` --> `CAN`
