### PR TITLE
cicd: revert dev termination time back to 12 hours

### DIFF
--- a/codebuild/deploy_eb_env_dev.py
+++ b/codebuild/deploy_eb_env_dev.py
@@ -3,7 +3,7 @@ import boto3
 import time
 elasticbeanstalk = boto3.client('elasticbeanstalk')
 servicecatalog = boto3.client('servicecatalog')
-terminate_time = 720
+terminate_time = 12
 eb_app_name = "VariationNormalization"
 eb_env_name = "VariationNormalization-dev-env"
 sc_product_id = "prod-m4b65t5jgmcm4"


### PR DESCRIPTION
close #318 

Kyle is no longer using our dev instance since they are running it in their cloud. So we can revert the termination time for dev back to 12