### PR TITLE
refactor: parsed_to_cn_var warning message

### DIFF
--- a/tests/to_copy_number_variation/test_parsed_to_cn_var.py
+++ b/tests/to_copy_number_variation/test_parsed_to_cn_var.py
@@ -203,7 +203,7 @@ def test_invalid(test_cnv_handler):
     """Test invalid queries returns Text variation and warnings"""
     # NCBI36/hg18 assembly
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/443961/?new_evidence=true
-    expected_w = ["NCBI36 assembly is not current supported"]
+    expected_w = ["NCBI36 assembly is not currently supported"]
     resp = test_cnv_handler.parsed_to_cn_var(
         2623228, 3150942, 3, assembly=ClinVarAssembly.NCBI36, chr="chr1",
         untranslatable_returns_text=True)

--- a/variation/to_copy_number_variation.py
+++ b/variation/to_copy_number_variation.py
@@ -231,7 +231,7 @@ class ToCopyNumberVariation(ToVRS):
                         if not accession:
                             warnings.append(f"Unable to find RefSeq accession for {query}")  # noqa: E501
                 else:
-                    warnings.append(f"{assembly.value} assembly is not current supported")  # noqa: E501
+                    warnings.append(f"{assembly.value} assembly is not currently supported")  # noqa: E501
             else:
                 warnings.append("Must provide either `accession` or both `assembly` "
                                 "and `chr`.")


### PR DESCRIPTION
Words are hard

Notes:
- "assembly is not current supported" --> "assembly is not currently supported"