### PR TITLE
fix: catch errors for (#_#)_#dup and #_(#_#)dup HGVS exprs

### DIFF
--- a/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
@@ -1201,3 +1201,13 @@ async def test_invalid_cnv(test_cnv_handler):
     assert set(resp.warnings) == {"Unable to translate braf v600e to copy number variation",  # noqa: E501
                                   "braf v600e is not a supported HGVS genomic duplication or deletion"}  # noqa: E501
     assert resp.copy_number_change is None
+
+    # Not yet supported
+    for q in ["NC_000018.9:g.(48556994_48573289)_48573471dup",
+              "NC_000018.9:g.48556994_(48573289_48573471)dup"]:
+        resp = await test_cnv_handler.hgvs_to_copy_number_change(
+            q, copy_change="efo:0030070"
+        )
+        assert resp.warnings == ["Unable to find valid result for classifications: "
+                                 "{'genomic duplication'}"], q
+        assert resp.copy_number_change is None, q

--- a/variation/validators/genomic_duplication.py
+++ b/variation/validators/genomic_duplication.py
@@ -259,6 +259,8 @@ class GenomicDuplication(DuplicationDeletionBase):
                 if not errors:
                     ival = self.vrs.get_start_end_definite_range(
                         start1, start2, end1, end2)
+            else:
+                errors.append("Not yet supported")
         else:
             if s.start_pos1_dup == "?" and s.end_pos2_dup == "?":
                 # format: (?_#)_(#_?)

--- a/variation/version.py
+++ b/variation/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.0-dev7"
+__version__ = "0.7.0-dev8"


### PR DESCRIPTION
Address #417 for metaschema branch 

This is a temporary fix. Eventually we will want to add support for these kinds of queries. I will make new issues now