### PR TITLE
fix: Copy Number Count copies should be Number or Indef/Def Range

### DIFF
--- a/tests/to_copy_number_variation/test_parsed_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_parsed_to_copy_number.py
@@ -657,9 +657,10 @@ def test_to_parsed_cn_var(
         assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
         start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
     )
-    resp == test_cnv_handler.parsed_to_copy_number(rb)
+    resp = test_cnv_handler.parsed_to_copy_number(rb)
     expected = deepcopy(cn_definite_number.dict())
-    expected["copies"] == {"type": "DefiniteRange", "min": 3, "max": 5}
+    expected["copies"] = {"type": "DefiniteRange", "min": 3, "max": 5}
+    expected["id"] = "ga4gh:CN.abS9SjAfusSTVgdX3kIUOGV8q8bmr5uO"
     assert resp.copy_number_count.dict() == expected
     assert resp.warnings == []
 
@@ -671,9 +672,10 @@ def test_to_parsed_cn_var(
         assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
         start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
     )
-    resp == test_cnv_handler.parsed_to_copy_number(rb)
+    resp = test_cnv_handler.parsed_to_copy_number(rb)
     expected = deepcopy(cn_definite_number.dict())
-    expected["copies"] == {"type": "IndefiniteRange", "comparator": "<=", "value": 3}
+    expected["copies"] = {"type": "IndefiniteRange", "comparator": "<=", "value": 3}
+    expected["id"] = "ga4gh:CN.2aMndMYx2uVCN-XcG-uLimeXkRRHGDCs"
     assert resp.copy_number_count.dict() == expected
     assert resp.warnings == []
 
@@ -685,9 +687,10 @@ def test_to_parsed_cn_var(
         assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
         start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
     )
-    resp == test_cnv_handler.parsed_to_copy_number(rb)
+    resp = test_cnv_handler.parsed_to_copy_number(rb)
     expected = deepcopy(cn_definite_number.dict())
-    expected["copies"] == {"type": "IndefiniteRange", "comparator": ">=", "value": 3}
+    expected["copies"] = {"type": "IndefiniteRange", "comparator": ">=", "value": 3}
+    expected["id"] = "ga4gh:CN.UDIZLBzw7TiaM7Q7Ani4BPoWyVbstlKu"
     assert resp.copy_number_count.dict() == expected
     assert resp.warnings == []
 

--- a/tests/to_copy_number_variation/test_parsed_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_parsed_to_copy_number.py
@@ -1,8 +1,10 @@
 """Test that parsed_to_copy_number works correctly"""
+from copy import deepcopy
+
 import pytest
 from ga4gh.vrs import models
 from ga4gh.vrsatile.pydantic.vrs_models import (
-    CopyNumberCount, CopyNumberChange, CopyChange, VRSTypes
+    CopyNumberCount, CopyNumberChange, CopyChange, VRSTypes, Comparator
 )
 from pydantic.error_wrappers import ValidationError
 
@@ -452,7 +454,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
     """Test that parsed_to_copy_number works for parsed copy number gain queries"""
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/145208/?new_evidence=true
     rb = ParsedToCnVarQuery(
-        start0=143134063, end0=143284670, total_copies=3,
+        start0=143134063, end0=143284670, copies0=3,
         assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -461,7 +463,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
     assert resp.warnings == []
 
     rb = ParsedToCnVarQuery(
-        start0=143134063, end0=143284670, total_copies=3, assembly=ClinVarAssembly.HG19,
+        start0=143134063, end0=143284670, copies0=3, assembly=ClinVarAssembly.HG19,
         chromosome="chr1", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -470,7 +472,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
     assert resp.warnings == []
 
     rb = ParsedToCnVarQuery(
-        start0=143134063, end0=143284670, total_copies=3, accession="NC_000001.10",
+        start0=143134063, end0=143284670, copies0=3, accession="NC_000001.10",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -480,7 +482,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/146181/?new_evidence=true
     # 38
     rb = ParsedToCnVarQuery(
-        start0=31738809, end0=32217725, total_copies=2, assembly=ClinVarAssembly.GRCH38,
+        start0=31738809, end0=32217725, copies0=2, assembly=ClinVarAssembly.GRCH38,
         chromosome="chr15", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -490,7 +492,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 38 with liftover (shouldnt do anything)
     rb = ParsedToCnVarQuery(
-        start0=31738809, end0=32217725, total_copies=2, assembly=ClinVarAssembly.GRCH38,
+        start0=31738809, end0=32217725, copies0=2, assembly=ClinVarAssembly.GRCH38,
         chromosome="chr15", do_liftover=True, start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -500,7 +502,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 38 with liftover (shouldnt do anything)
     rb = ParsedToCnVarQuery(
-        start0=31738809, end0=32217725, total_copies=2, assembly=ClinVarAssembly.HG38,
+        start0=31738809, end0=32217725, copies0=2, assembly=ClinVarAssembly.HG38,
         chromosome="chr15", do_liftover=True, start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -510,7 +512,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 38
     rb = ParsedToCnVarQuery(
-        start0=31738809, end0=32217725, total_copies=2, assembly=ClinVarAssembly.HG38,
+        start0=31738809, end0=32217725, copies0=2, assembly=ClinVarAssembly.HG38,
         chromosome="chr15", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -520,7 +522,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 38 accession
     rb = ParsedToCnVarQuery(
-        start0=31738809, end0=32217725, total_copies=2, accession="NC_000015.10",
+        start0=31738809, end0=32217725, copies0=2, accession="NC_000015.10",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -529,7 +531,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 38 accession with liftover (shouldnt do anything)
     rb = ParsedToCnVarQuery(
-        start0=31738809, end0=32217725, total_copies=2, accession="NC_000015.10",
+        start0=31738809, end0=32217725, copies0=2, accession="NC_000015.10",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -538,7 +540,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 37 with liftover
     rb = ParsedToCnVarQuery(
-        start0=32031012, end0=32509926, total_copies=2, accession="NC_000015.9",
+        start0=32031012, end0=32509926, copies0=2, accession="NC_000015.9",
         start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE, do_liftover=True
     )
@@ -548,7 +550,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 37 chr+accession with liftover
     rb = ParsedToCnVarQuery(
-        start0=32031012, end0=32509926, total_copies=2, chromosome="chr15",
+        start0=32031012, end0=32509926, copies0=2, chromosome="chr15",
         assembly=ClinVarAssembly.GRCH37, start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE, do_liftover=True
     )
@@ -558,7 +560,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 37 with no liftover
     rb = ParsedToCnVarQuery(
-        start0=32031012, end0=32509926, total_copies=2, accession="NC_000015.9",
+        start0=32031012, end0=32509926, copies0=2, accession="NC_000015.9",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -567,7 +569,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
 
     # 37 chr+accession with no liftover
     rb = ParsedToCnVarQuery(
-        start0=32031012, end0=32509926, total_copies=2, chromosome="chr15",
+        start0=32031012, end0=32509926, copies0=2, chromosome="chr15",
         assembly=ClinVarAssembly.GRCH37, start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -581,7 +583,7 @@ def test_parsed_copy_number_loss(test_cnv_handler, cn_loss1,
     """Test that parsed_to_copy_number works for parsed copy number loss queries"""
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/1299222/?new_evidence=true
     rb = ParsedToCnVarQuery(
-        start0=10491132, end0=10535643, total_copies=1, assembly=ClinVarAssembly.GRCH37,
+        start0=10491132, end0=10535643, copies0=1, assembly=ClinVarAssembly.GRCH37,
         chromosome="chrX", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -590,7 +592,7 @@ def test_parsed_copy_number_loss(test_cnv_handler, cn_loss1,
     assert resp.warnings == []
 
     rb = ParsedToCnVarQuery(
-        start0=10491132, end0=10535643, total_copies=1, assembly=ClinVarAssembly.HG19,
+        start0=10491132, end0=10535643, copies0=1, assembly=ClinVarAssembly.HG19,
         chromosome="chrX", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -599,7 +601,7 @@ def test_parsed_copy_number_loss(test_cnv_handler, cn_loss1,
     assert resp.warnings == []
 
     rb = ParsedToCnVarQuery(
-        start0=10491132, end0=10535643, total_copies=1, accession="NC_000023.10",
+        start0=10491132, end0=10535643, copies0=1, accession="NC_000023.10",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -608,7 +610,7 @@ def test_parsed_copy_number_loss(test_cnv_handler, cn_loss1,
 
     # https://www.ncbi.nlm.nih.gov/clinvar/variation/148425/?new_evidence=true
     rb = ParsedToCnVarQuery(
-        start0=10001, end0=1223133, total_copies=0, assembly=ClinVarAssembly.GRCH38,
+        start0=10001, end0=1223133, copies0=0, assembly=ClinVarAssembly.GRCH38,
         chromosome="chrY", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -617,7 +619,7 @@ def test_parsed_copy_number_loss(test_cnv_handler, cn_loss1,
     assert resp.warnings == []
 
     rb = ParsedToCnVarQuery(
-        start0=10001, end0=1223133, total_copies=0, assembly=ClinVarAssembly.HG38,
+        start0=10001, end0=1223133, copies0=0, assembly=ClinVarAssembly.HG38,
         chromosome="chrY", start_pos_type=VRSTypes.INDEFINITE_RANGE,
         end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
@@ -626,7 +628,7 @@ def test_parsed_copy_number_loss(test_cnv_handler, cn_loss1,
     assert resp.warnings == []
 
     rb = ParsedToCnVarQuery(
-        start0=10001, end0=1223133, total_copies=0, accession="NC_000024.10",
+        start0=10001, end0=1223133, copies0=0, accession="NC_000024.10",
         start_pos_type=VRSTypes.INDEFINITE_RANGE, end_pos_type=VRSTypes.INDEFINITE_RANGE
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -640,12 +642,53 @@ def test_to_parsed_cn_var(
     """Test that parsed_to_copy_number works correctly for copy number count"""
     # start uses definite and end uses number
     rb = ParsedToCnVarQuery(
-        start0=143134063, end0=143284670, total_copies=3,
+        start0=143134063, end0=143284670, copies0=3,
         assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
         start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
     assert resp.copy_number_count.dict() == cn_definite_number.dict()
+    assert resp.warnings == []
+
+    # copies is definite range
+    rb = ParsedToCnVarQuery(
+        start0=143134063, end0=143284670, copies0=3, copies1=5,
+        copies_type=VRSTypes.DEFINITE_RANGE,
+        assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
+        start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
+    )
+    resp == test_cnv_handler.parsed_to_copy_number(rb)
+    expected = deepcopy(cn_definite_number.dict())
+    expected["copies"] == {"type": "DefiniteRange", "min": 3, "max": 5}
+    assert resp.copy_number_count.dict() == expected
+    assert resp.warnings == []
+
+    # copies is indefinite range <=
+    rb = ParsedToCnVarQuery(
+        start0=143134063, end0=143284670, copies0=3,
+        copies_comparator=Comparator.LT_OR_EQUAL,
+        copies_type=VRSTypes.INDEFINITE_RANGE,
+        assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
+        start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
+    )
+    resp == test_cnv_handler.parsed_to_copy_number(rb)
+    expected = deepcopy(cn_definite_number.dict())
+    expected["copies"] == {"type": "IndefiniteRange", "comparator": "<=", "value": 3}
+    assert resp.copy_number_count.dict() == expected
+    assert resp.warnings == []
+
+    # copies is indefinite range >=
+    rb = ParsedToCnVarQuery(
+        start0=143134063, end0=143284670, copies0=3,
+        copies_comparator=Comparator.GT_OR_EQUAL,
+        copies_type=VRSTypes.INDEFINITE_RANGE,
+        assembly=ClinVarAssembly.GRCH37, chromosome="chr1",
+        start_pos_type=VRSTypes.DEFINITE_RANGE, start1=143134065
+    )
+    resp == test_cnv_handler.parsed_to_copy_number(rb)
+    expected = deepcopy(cn_definite_number.dict())
+    expected["copies"] == {"type": "IndefiniteRange", "comparator": ">=", "value": 3}
+    assert resp.copy_number_count.dict() == expected
     assert resp.warnings == []
 
 
@@ -806,3 +849,23 @@ def test_invalid(test_cnv_handler):
             start_pos_type=VRSTypes.DEFINITE_RANGE
         )
     assert "`start1` is required for definite ranges" in str(e.value)
+
+    # copies1 not provided when copies_type is DefiniteRange
+    with pytest.raises(ValidationError) as e:
+        ParsedToCnVarQuery(
+            start0=143134063, end0=143284670, copies0=3,
+            copies_type=VRSTypes.DEFINITE_RANGE, assembly=ClinVarAssembly.GRCH37,
+            chromosome="chr1", start_pos_type=VRSTypes.INDEFINITE_RANGE,
+            end_pos_type=VRSTypes.INDEFINITE_RANGE
+        )
+    assert "`copies1` must be provided for `copies_type == DefiniteRange`" in str(e.value)  # noqa: E501
+
+    # copies_comparator not provided when copies_type is IndefiniteRange
+    with pytest.raises(ValidationError) as e:
+        ParsedToCnVarQuery(
+            start0=143134063, end0=143284670, copies0=3,
+            copies_type=VRSTypes.INDEFINITE_RANGE, assembly=ClinVarAssembly.GRCH37,
+            chromosome="chr1", start_pos_type=VRSTypes.INDEFINITE_RANGE,
+            end_pos_type=VRSTypes.INDEFINITE_RANGE
+        )
+    assert "`copies_comparator` must be provided for `copies_type == IndefiniteRange`" in str(e.value)  # noqa: E501

--- a/variation/schemas/copy_number_schema.py
+++ b/variation/schemas/copy_number_schema.py
@@ -3,10 +3,12 @@ import re
 from enum import Enum
 from typing import Optional, Union, Dict, Any, Type, Literal
 
-from pydantic import BaseModel, StrictStr, root_validator, StrictInt, StrictBool
+from pydantic import BaseModel, StrictStr, root_validator, StrictInt, StrictBool, Field
 from pydantic.main import ModelMetaclass
-from ga4gh.vrsatile.pydantic.vrs_models import CopyNumberCount, Text, \
-    SequenceLocation, CopyNumberChange, CopyChange, VRSTypes
+from ga4gh.vrsatile.pydantic.vrs_models import (
+    CopyNumberCount, Text, SequenceLocation, CopyNumberChange, CopyChange, VRSTypes,
+    Comparator
+)
 
 from variation.version import __version__
 from variation.schemas.normalize_response_schema import ServiceResponse
@@ -26,21 +28,64 @@ class ClinVarAssembly(str, Enum):
 class ParsedToCopyNumberQuery(BaseModel):
     """Define base model for parsed to copy number queries"""
 
-    assembly: Optional[ClinVarAssembly] = None
-    chromosome: Optional[StrictStr] = None
-    accession: Optional[StrictStr] = None
-    start0: StrictInt
-    end0: StrictInt
+    assembly: Optional[ClinVarAssembly] = Field(
+        None,
+        description=("Assembly. Ignored, along with `chromosome`, if `accession` is "
+                     "provided.")
+    )
+    chromosome: Optional[StrictStr] = Field(
+        None,
+        description=("Chromosome. Must contain `chr` prefix, i.e. 'chr7'. Must provide "
+                     "when `assembly` is provided.")
+    )
+    accession: Optional[StrictStr] = Field(
+        None,
+        description=("Genomic RefSeq accession. If `accession` is provided, will "
+                     "ignore `assembly` and `chromosome`. If `accession` is not "
+                     "provided, must provide both `assembly` and `chromosome`.")
+    )
+    start0: StrictInt = Field(
+        ...,
+        description=("Start position (residue coords). If `start_pos_type` is a "
+                     "Definite Range, this will be the min start position.")
+    )
+    end0: StrictInt = Field(
+        ...,
+        description=("End position (residue coords). If `end_pos_type` is a definite "
+                     "range, this will be the min end position.")
+    )
     start_pos_type: Literal[
         VRSTypes.NUMBER, VRSTypes.DEFINITE_RANGE, VRSTypes.INDEFINITE_RANGE
-    ] = VRSTypes.NUMBER
+    ] = Field(
+        VRSTypes.NUMBER,
+        description="The type of the start value in the VRS SequenceLocation"
+    )
     end_pos_type: Literal[
         VRSTypes.NUMBER, VRSTypes.DEFINITE_RANGE, VRSTypes.INDEFINITE_RANGE
-    ] = VRSTypes.NUMBER
-    start1: Optional[StrictInt]
-    end1: Optional[StrictInt]
-    do_liftover: StrictBool = False
-    untranslatable_returns_text: StrictBool = False
+    ] = Field(
+        VRSTypes.NUMBER,
+        description="Type of the end value in the VRS SequenceLocation"
+    )
+    start1: Optional[StrictInt] = Field(
+        None,
+        description=("Only provided when `start_pos_type` is a Definite Range, this "
+                     "will be the max start position.")
+    )
+    end1: Optional[StrictInt] = Field(
+        None,
+        description=("Only provided when `end_pos_type` is a Definite Range, this "
+                     "will be the max end position.")
+    )
+    do_liftover: StrictBool = Field(
+        False,
+        description="Whether or not to liftover to GRCh38 assembly"
+    )
+    untranslatable_returns_text: StrictBool = Field(
+        False,
+        description=("When set to `True`, return VRS Text Object when unable to "
+                     "translate or normalize query. When set to `False`, return `None` "
+                     "when unable to translate or normalize query.")
+    )
 
     @root_validator(pre=False, skip_on_failure=True)
     def validate_fields(cls: ModelMetaclass, v: Dict) -> Dict:
@@ -48,7 +93,7 @@ class ParsedToCopyNumberQuery(BaseModel):
         - `accession` or both `assembly` and `chromosome` must be provided
         - `start1` is required when `start_pos_type` is a definite
         range.
-        - `end1` is required when `end_pos_type` is a definite range.
+        - `end1` is required when `end_pos_type` is a Definite Range.
         - End positions must be greater than start positions
         """
         ac_assembly_chr_msg = "Must provide either `accession` or both `assembly` and `chromosome`"  # noqa: E501
@@ -85,7 +130,47 @@ class ParsedToCopyNumberQuery(BaseModel):
 class ParsedToCnVarQuery(ParsedToCopyNumberQuery):
     """Define query for parsed to copy number count variation endpoint"""
 
-    total_copies: StrictInt
+    copies0: StrictInt = Field(
+        ...,
+        description=("Number of copies. When `copies_type` is a Number or Indefinite "
+                     "Range, this will be the `value` for copies. When `copies_type` "
+                     "is an Definite Range, this will be the `min` copies.")
+    )
+    copies1: Optional[StrictInt] = Field(
+        None,
+        description=("Must provide when `copies_type` is a Definite Range. This will "
+                     "be the `max` copies.")
+    )
+    copies_type: Literal[
+        VRSTypes.NUMBER, VRSTypes.DEFINITE_RANGE, VRSTypes.INDEFINITE_RANGE
+    ] = Field(
+        VRSTypes.NUMBER,
+        description="Type for the `copies` in the `subject`"
+    )
+    copies_comparator: Optional[Comparator] = Field(
+        None,
+        description=("Must provide when `copies_type` is an Indefinite Range. "
+                     "Indicates which direction the range is indefinite.")
+    )
+
+    @root_validator(pre=False, skip_on_failure=True)
+    def validate_fields(cls: ModelMetaclass, v: Dict) -> Dict:
+        """Validate fields.
+
+        - `copies1` should exist when `copies_type == VRSTypes.DEFINITE_RANGE`
+        - `copies_comparator` should exist when
+            `copies_type == VRSTypes.INDEFINITE_RANGE`
+        """
+        copies1 = v.get("copies1")
+        copies_type = v.get("copies_type")
+        copies_comparator = v.get("copies_comparator")
+
+        if copies_type == VRSTypes.DEFINITE_RANGE:
+            assert copies1, "`copies1` must be provided for `copies_type == DefiniteRange`"  # noqa: E501
+        elif copies_type == VRSTypes.INDEFINITE_RANGE:
+            assert copies_comparator, "`copies_comparator` must be provided for `copies_type == IndefiniteRange`"  # noqa: E501
+
+        return v
 
     class Config:
         """Configure model."""
@@ -104,7 +189,10 @@ class ParsedToCnVarQuery(ParsedToCopyNumberQuery):
                 "accession": None,
                 "start0": 143134063,
                 "end0": 143284670,
-                "total_copies": 3,
+                "copies0": 3,
+                "copies1": None,
+                "copies_comparator": None,
+                "copies_type": "Number",
                 "start_pos_type": "IndefiniteRange",
                 "end_pos_type": "IndefiniteRange",
                 "start1": None,

--- a/variation/schemas/copy_number_schema.py
+++ b/variation/schemas/copy_number_schema.py
@@ -134,7 +134,7 @@ class ParsedToCnVarQuery(ParsedToCopyNumberQuery):
         ...,
         description=("Number of copies. When `copies_type` is a Number or Indefinite "
                      "Range, this will be the `value` for copies. When `copies_type` "
-                     "is an Definite Range, this will be the `min` copies.")
+                     "is a Definite Range, this will be the `min` copies.")
     )
     copies1: Optional[StrictInt] = Field(
         None,

--- a/variation/to_copy_number_variation.py
+++ b/variation/to_copy_number_variation.py
@@ -534,10 +534,28 @@ class ToCopyNumberVariation(ToVRS):
                 )
                 variation = CopyNumberChange(**variation)
             else:
+                if request_body.copies_type == VRSTypes.NUMBER:
+                    copies = {
+                        "value": request_body.copies0,
+                        "type": "Number"
+                    }
+                elif request_body.copies_type == VRSTypes.DEFINITE_RANGE:
+                    copies = {
+                        "min": request_body.copies0,
+                        "max": request_body.copies1,
+                        "type": "DefiniteRange"
+                    }
+                else:
+                    copies = {
+                        "value": request_body.copies0,
+                        "comparator": request_body.copies_comparator.value,
+                        "type": "IndefiniteRange"
+                    }
+
                 variation = {
                     "type": "CopyNumberCount",
                     "subject": seq_loc,
-                    "copies": {"value": request_body.total_copies, "type": "Number"}
+                    "copies": copies
                 }
                 variation["id"] = ga4gh_identify(
                     models.CopyNumberCount(**variation)


### PR DESCRIPTION
Addresses #443  for metaschema branch. Needed for manuscript analysis

- Provides descriptions for Parsed to CN query classes
- `total_copies` renamed to `copies0`