### PR TITLE
fix: add `input_assembly` param for gnomad vcf / genomic free text queries

### DIFF
--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -8,6 +8,7 @@ from ga4gh.vrsatile.pydantic.vrsatile_models import VariationDescriptor
 from tests.conftest import assertion_checks
 from variation.main import normalize as normalize_get_response
 from variation.main import to_vrs as to_vrs_get_response
+from variation.schemas.service_schema import ClinVarAssembly
 
 
 @pytest.fixture(scope="module")
@@ -559,6 +560,91 @@ def gnomad_vcf_genomic_sub_mnv():
 
 
 @pytest.fixture(scope="module")
+def gnomad_vcf_genomic_sub_input_assembly37():
+    """Create a genomic substitution test fixture for 3-10191647-T-G using GRCh37."""
+    params = {
+        "id": "normalize.variation:3-10191647-T-G",
+        "type": "VariationDescriptor",
+        "variation_id": "ga4gh:VA.7nGd8dgHbqtxMHk_rLxrB6_IMAzJ8XnH",
+        "variation": {
+            "_id": "ga4gh:VA.7nGd8dgHbqtxMHk_rLxrB6_IMAzJ8XnH",
+            "location": {
+                "_id": "ga4gh:VSL.pSGVx7B8xIG42qV_TfXSXkhINDHVwW1L",
+                "interval": {
+                    "start": {"value": 10149962, "type": "Number"},
+                    "end": {"value": 10149963, "type": "Number"},
+                    "type": "SequenceInterval",
+                },
+                "sequence_id": "ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX",
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+        "molecule_context": "genomic",
+        "vrs_ref_allele_seq": "T",
+    }
+    return VariationDescriptor(**params)
+
+
+@pytest.fixture(scope="module")
+def gnomad_vcf_genomic_sub_input_assembly38():
+    """Create a genomic substitution test fixture for 3-10191647-T-G using GRCh38."""
+    params = {
+        "id": "normalize.variation:3-10191647-T-G",
+        "type": "VariationDescriptor",
+        "variation_id": "ga4gh:VA.MxbEL0NnlGXBnIiHv7KKjH4Lg0X2Gw-V",
+        "variation": {
+            "_id": "ga4gh:VA.MxbEL0NnlGXBnIiHv7KKjH4Lg0X2Gw-V",
+            "location": {
+                "_id": "ga4gh:VSL.sl5rcObbcolSsMrFDWUAYQmFlXwjIPJ7",
+                "interval": {
+                    "end": {"value": 10191647, "type": "Number"},
+                    "start": {"value": 10191646, "type": "Number"},
+                    "type": "SequenceInterval",
+                },
+                "sequence_id": "ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX",
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+        "molecule_context": "genomic",
+        "vrs_ref_allele_seq": "T",
+    }
+    return VariationDescriptor(**params)
+
+
+@pytest.fixture(scope="module")
+def free_text_genomic_sub_input_assembly():
+    """Create a genomic substitution test fixture for VHL g.10191647T>G."""
+    params = {
+        "id": "normalize.variation:VHL%20g.10191647T%3EG",
+        "type": "VariationDescriptor",
+        "variation_id": "ga4gh:VA.V_RCy-Yfqh97VmrxOKVEesKvEqe05bWz",
+        "variation": {
+            "_id": "ga4gh:VA.V_RCy-Yfqh97VmrxOKVEesKvEqe05bWz",
+            "location": {
+                "_id": "ga4gh:VSL.Uoo8Z7gyzy1GWYJPyEepinT0aqhJ0xqm",
+                "interval": {
+                    "end": {"value": 710, "type": "Number"},
+                    "start": {"value": 709, "type": "Number"},
+                    "type": "SequenceInterval",
+                },
+                "sequence_id": "ga4gh:SQ.xBKOKptLLDr-k4hTyCetvARn16pDS_rW",
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+        "molecule_context": "transcript",
+        "vrs_ref_allele_seq": "T",
+        "gene_context": "hgnc:12687",
+    }
+    return VariationDescriptor(**params)
+
+
+@pytest.fixture(scope="module")
 def genomic_sub_grch38():
     """Create a genomic substitution GRCh38 test fixture."""
     params = {
@@ -890,6 +976,9 @@ async def test_cdna_and_genomic_substitution(
     genomic_sub_grch38,
     grch38_braf_genom_sub,
     gnomad_vcf_genomic_sub_mnv,
+    gnomad_vcf_genomic_sub_input_assembly37,
+    gnomad_vcf_genomic_sub_input_assembly38,
+    free_text_genomic_sub_input_assembly,
 ):
     """Test that cdna and genomic substitutions normalize correctly."""
     resp = await test_handler.normalize("NM_004333.4:c.1799T>A")
@@ -988,6 +1077,43 @@ async def test_cdna_and_genomic_substitution(
     q = "5-112175770-GGAA-AGAA"
     resp = await test_handler.normalize(q)
     assertion_checks(resp.variation_descriptor, gnomad_vcf_genomic_sub_mnv, q)
+
+    # Test gnomad vcf input assembly when both GRCh37 and GRCh38 are valid (CA351756720)
+    q = "3-10191647-T-G"
+    resp = await test_handler.normalize(q, input_assembly=ClinVarAssembly.GRCH37)
+    assertion_checks(
+        resp.variation_descriptor, gnomad_vcf_genomic_sub_input_assembly37, q
+    )
+
+    resp1 = await test_handler.normalize(q, input_assembly=ClinVarAssembly.GRCH38)
+    assertion_checks(
+        resp1.variation_descriptor, gnomad_vcf_genomic_sub_input_assembly38, q
+    )
+
+    resp2 = await test_handler.normalize(q)
+    assert (
+        resp2.variation_descriptor.variation.id
+        == resp1.variation_descriptor.variation.id
+    )
+
+    # Test free text input assembly when both GRCh37 and GRCh38 are valid (CA351756720)
+    q = "VHL g.10191647T>G"
+    resp1 = await test_handler.normalize(q, input_assembly=ClinVarAssembly.GRCH37)
+    assertion_checks(
+        resp1.variation_descriptor, free_text_genomic_sub_input_assembly, q
+    )
+
+    resp2 = await test_handler.normalize(q, input_assembly=ClinVarAssembly.GRCH38)
+    assert (
+        resp2.variation_descriptor.variation.id
+        == resp1.variation_descriptor.variation.id
+    )
+
+    resp3 = await test_handler.normalize(q)
+    assert (
+        resp3.variation_descriptor.variation.id
+        == resp2.variation_descriptor.variation.id
+    )
 
 
 @pytest.mark.asyncio

--- a/variation/main.py
+++ b/variation/main.py
@@ -1,7 +1,7 @@
 """Main application for FastAPI."""
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 from urllib.parse import unquote
 
 import pkg_resources
@@ -167,6 +167,12 @@ async def normalize(
     hgvs_dup_del_mode: Optional[HGVSDupDelModeOption] = Query(
         HGVSDupDelModeOption.DEFAULT, description=hgvs_dup_del_mode_decsr
     ),
+    input_assembly: Optional[
+        Literal[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+    ] = Query(
+        None,
+        description="Assembly used for `q`. Only used when `q` is using genomic free text or gnomad vcf format",
+    ),
     baseline_copies: Optional[int] = Query(
         None,
         description="Baseline copies for HGVS duplications and deletions represented as Copy Number Count Variation",  # noqa: E501
@@ -182,24 +188,25 @@ async def normalize(
     fully-justified allele normalization. Will liftover to GRCh38 and aligns to a
     priority transcript. Will make inferences about the query.
 
-    :param str q: HGVS, gnomAD VCF or Free Text description on GRCh37 or GRCh38 assembly
-    :param Optional[HGVSDupDelModeOption] hgvs_dup_del_mode: Must be: `default`,
-        `copy_number_count`, `copy_number_change`, `repeated_seq_expr`,
-        `literal_seq_expr`. This parameter determines how to interpret HGVS dup/del
+    :param q: HGVS, gnomAD VCF or Free Text description on GRCh37 or GRCh38 assembly
+    :param hgvs_dup_del_mode: This parameter determines how to interpret HGVS dup/del
         expressions in VRS.
-    :param Optional[int] baseline_copies: Baseline copies for HGVS duplications and
-        deletions. Required when `hgvs_dup_del_mode` is set to `copy_number_count`.
-    :param Optional[CopyChange] copy_change: The copy change
-        for HGVS duplications and deletions represented as Copy Number Change
-        Variation. If not set, will use default `copy_change` for query.
-    :param bool untranslatable_returns_text: `True` return VRS Text Object when
-        unable to translate or normalize query. `False` return `None` when
-        unable to translate or normalize query.
+    :param input_assembly: Assembly used for `q`. Only used when `q` is using genomic
+        free text or gnomad vcf format
+    :param baseline_copies: Baseline copies for HGVS duplications and deletions.
+        Required when `hgvs_dup_del_mode` is set to `copy_number_count`.
+    :param copy_change: The copy change for HGVS duplications and deletions represented
+        as Copy Number Change Variation. If not set, will use default `copy_change` for
+        query.
+    :param untranslatable_returns_text: `True` return VRS Text Object when unable to
+        translate or normalize query. `False` return `None` when unable to translate or
+        normalize query.
     :return: NormalizeService for variation
     """
     normalize_resp = await query_handler.normalize_handler.normalize(
         unquote(q),
         hgvs_dup_del_mode=hgvs_dup_del_mode,
+        input_assembly=input_assembly,
         baseline_copies=baseline_copies,
         copy_change=copy_change,
         untranslatable_returns_text=untranslatable_returns_text,

--- a/variation/validators/amplification.py
+++ b/variation/validators/amplification.py
@@ -1,11 +1,12 @@
 """Module for Amplification validation"""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     AmplificationClassification,
     Classification,
     ClassificationType,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -41,12 +42,19 @@ class Amplification(Validator):
         return classification_type == ClassificationType.AMPLIFICATION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List:
         """Return empty list since amplification does not require accessions
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: Empty list
         """
         return []

--- a/variation/validators/cdna_deletion.py
+++ b/variation/validators/cdna_deletion.py
@@ -1,5 +1,5 @@
 """The module for cDNA Deletion Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     CdnaDeletionClassification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     ClassificationType,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -94,7 +95,12 @@ class CdnaDeletion(Validator):
         return classification_type == ClassificationType.CDNA_DELETION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -103,6 +109,8 @@ class CdnaDeletion(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/cdna_delins.py
+++ b/variation/validators/cdna_delins.py
@@ -1,5 +1,5 @@
 """The module for Cdna DelIns Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     CdnaDelInsClassification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     ClassificationType,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -75,7 +76,12 @@ class CdnaDelIns(Validator):
         return classification_type == ClassificationType.CDNA_DELINS
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -84,6 +90,8 @@ class CdnaDelIns(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/cdna_insertion.py
+++ b/variation/validators/cdna_insertion.py
@@ -1,5 +1,5 @@
 """The module for Cdna Insertion Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     CdnaInsertionClassification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     ClassificationType,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -73,7 +74,12 @@ class CdnaInsertion(Validator):
         return classification_type == ClassificationType.CDNA_INSERTION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -82,6 +88,8 @@ class CdnaInsertion(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/cdna_reference_agree.py
+++ b/variation/validators/cdna_reference_agree.py
@@ -1,5 +1,5 @@
 """The module for Cdna Substitution Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     CdnaReferenceAgreeClassification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     ClassificationType,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -57,7 +58,12 @@ class CdnaReferenceAgree(Validator):
         return classification_type == ClassificationType.CDNA_REFERENCE_AGREE
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -66,6 +72,8 @@ class CdnaReferenceAgree(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/cdna_substitution.py
+++ b/variation/validators/cdna_substitution.py
@@ -1,5 +1,5 @@
 """The module for cDNA Substitution Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     CdnaSubstitutionClassification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     ClassificationType,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -60,7 +61,12 @@ class CdnaSubstitution(Validator):
         return classification_type == ClassificationType.CDNA_SUBSTITUTION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -69,6 +75,8 @@ class CdnaSubstitution(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/genomic_base.py
+++ b/variation/validators/genomic_base.py
@@ -70,7 +70,7 @@ class GenomicBase:
                 if ac:
                     nc_accessions.append(ac)
             else:
-                for assembly in [ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]:
+                for assembly in [ClinVarAssembly.GRCH38, ClinVarAssembly.GRCH37]:
                     ac = self.get_nc_accession(f"{assembly.value}:{chromosome}")
                     if ac:
                         nc_accessions.append(ac)

--- a/variation/validators/genomic_deletion.py
+++ b/variation/validators/genomic_deletion.py
@@ -1,5 +1,5 @@
 """The module for Genomic Deletion Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     GenomicDeletionClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -107,7 +108,12 @@ class GenomicDeletion(Validator):
         return classification_type == ClassificationType.GENOMIC_DELETION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -116,10 +122,14 @@ class GenomicDeletion(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_deletion_ambiguous.py
+++ b/variation/validators/genomic_deletion_ambiguous.py
@@ -1,5 +1,5 @@
 """The module for Genomic Deletion Ambiguous Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     AmbiguousType,
@@ -8,6 +8,7 @@ from variation.schemas.classification_response_schema import (
     GenomicDeletionAmbiguousClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -103,7 +104,12 @@ class GenomicDeletionAmbiguous(Validator):
         return classification_type == ClassificationType.GENOMIC_DELETION_AMBIGUOUS
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -112,10 +118,14 @@ class GenomicDeletionAmbiguous(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_delins.py
+++ b/variation/validators/genomic_delins.py
@@ -1,5 +1,5 @@
 """The module for Genomic DelIns Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     GenomicDelInsClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -84,7 +85,12 @@ class GenomicDelIns(Validator):
         return classification_type == ClassificationType.GENOMIC_DELINS
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -93,10 +99,14 @@ class GenomicDelIns(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_duplication.py
+++ b/variation/validators/genomic_duplication.py
@@ -1,5 +1,5 @@
 """The module for Genomic Duplication Validation."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     GenomicDuplicationClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -77,7 +78,12 @@ class GenomicDuplication(Validator):
         return classification_type == ClassificationType.GENOMIC_DUPLICATION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> Optional[List[str]]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -86,10 +92,14 @@ class GenomicDuplication(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_duplication_ambiguous.py
+++ b/variation/validators/genomic_duplication_ambiguous.py
@@ -1,5 +1,5 @@
 """The module for Genomic Duplication Ambiguous Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     AmbiguousType,
@@ -8,6 +8,7 @@ from variation.schemas.classification_response_schema import (
     GenomicDuplicationAmbiguousClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -103,7 +104,12 @@ class GenomicDuplicationAmbiguous(Validator):
         return classification_type == ClassificationType.GENOMIC_DUPLICATION_AMBIGUOUS
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -112,10 +118,14 @@ class GenomicDuplicationAmbiguous(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_insertion.py
+++ b/variation/validators/genomic_insertion.py
@@ -1,5 +1,5 @@
 """The module for Genomic Insertion Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     GenomicInsertionClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -79,7 +80,12 @@ class GenomicInsertion(Validator):
         return classification_type == ClassificationType.GENOMIC_INSERTION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -88,10 +94,14 @@ class GenomicInsertion(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_reference_agree.py
+++ b/variation/validators/genomic_reference_agree.py
@@ -1,5 +1,5 @@
 """The module for Genomic Reference Agree Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     GenomicReferenceAgreeClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -64,7 +65,12 @@ class GenomicReferenceAgree(Validator):
         return classification_type == ClassificationType.GENOMIC_REFERENCE_AGREE
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -73,10 +79,14 @@ class GenomicReferenceAgree(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/genomic_substitution.py
+++ b/variation/validators/genomic_substitution.py
@@ -1,5 +1,5 @@
 """The module for Genomic Substitution Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     GenomicSubstitutionClassification,
     Nomenclature,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -60,7 +61,12 @@ class GenomicSubstitution(Validator):
         return classification_type == ClassificationType.GENOMIC_SUBSTITUTION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -69,10 +75,14 @@ class GenomicSubstitution(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:
             accessions = [classification.ac]
         else:
-            accessions = await self.get_genomic_accessions(classification, errors)
+            accessions = await self.get_genomic_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         return accessions

--- a/variation/validators/protein_deletion.py
+++ b/variation/validators/protein_deletion.py
@@ -1,5 +1,5 @@
 """The module for Protein Deletion Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     Nomenclature,
     ProteinDeletionClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -109,7 +110,12 @@ class ProteinDeletion(Validator):
         return classification_type == ClassificationType.PROTEIN_DELETION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -118,6 +124,8 @@ class ProteinDeletion(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/protein_delins.py
+++ b/variation/validators/protein_delins.py
@@ -1,5 +1,5 @@
 """The module for Protein DelIns Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     Nomenclature,
     ProteinDelInsClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -91,7 +92,12 @@ class ProteinDelIns(Validator):
         return classification_type == ClassificationType.PROTEIN_DELINS
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -100,6 +106,8 @@ class ProteinDelIns(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/protein_insertion.py
+++ b/variation/validators/protein_insertion.py
@@ -1,5 +1,5 @@
 """The module for Protein Insertion Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     Nomenclature,
     ProteinInsertionClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -91,7 +92,12 @@ class ProteinInsertion(Validator):
         return classification_type == ClassificationType.PROTEIN_INSERTION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -100,6 +106,8 @@ class ProteinInsertion(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/protein_reference_agree.py
+++ b/variation/validators/protein_reference_agree.py
@@ -1,5 +1,5 @@
 """The module for Protein Reference Agree Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     Nomenclature,
     ProteinReferenceAgreeClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -68,7 +69,12 @@ class ProteinReferenceAgree(Validator):
         return classification_type == ClassificationType.PROTEIN_REFERENCE_AGREE
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -77,6 +83,8 @@ class ProteinReferenceAgree(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/protein_stop_gain.py
+++ b/variation/validators/protein_stop_gain.py
@@ -1,5 +1,5 @@
 """The module for Protein Stop Gain Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     Nomenclature,
     ProteinStopGainClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -71,7 +72,12 @@ class ProteinStopGain(Validator):
         return classification_type == ClassificationType.PROTEIN_STOP_GAIN
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -80,6 +86,8 @@ class ProteinStopGain(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/protein_substitution.py
+++ b/variation/validators/protein_substitution.py
@@ -1,5 +1,5 @@
 """The module for Protein Substitution Validation."""
-from typing import List
+from typing import List, Optional, Union
 
 from variation.schemas.classification_response_schema import (
     Classification,
@@ -7,6 +7,7 @@ from variation.schemas.classification_response_schema import (
     Nomenclature,
     ProteinSubstitutionClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.validators.validator import Validator
 
@@ -68,7 +69,12 @@ class ProteinSubstitution(Validator):
         return classification_type == ClassificationType.PROTEIN_SUBSTITUTION
 
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -77,6 +83,8 @@ class ProteinSubstitution(Validator):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
         if classification.nomenclature == Nomenclature.HGVS:

--- a/variation/validators/validator.py
+++ b/variation/validators/validator.py
@@ -172,7 +172,8 @@ class Validator(ABC):
 
         :param classification: Classification for a list of tokens
         :param errors: List of errors
-        :param input_assembly: Assembly used for initial query
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of possible genomic RefSeq accessions for the variation
         """
         accessions = await self.genomic_base.get_nc_accessions(

--- a/variation/validators/validator.py
+++ b/variation/validators/validator.py
@@ -19,6 +19,7 @@ from variation.schemas.classification_response_schema import (
     ProteinStopGainClassification,
     ProteinSubstitutionClassification,
 )
+from variation.schemas.service_schema import ClinVarAssembly
 from variation.schemas.token_response_schema import GeneToken
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.utils import get_aa1_codes
@@ -50,7 +51,12 @@ class Validator(ABC):
 
     @abstractmethod
     async def get_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get accessions for a given classification.
         If `classification.nomenclature == Nomenclature.HGVS`, will return the accession
@@ -59,6 +65,8 @@ class Validator(ABC):
 
         :param classification: The classification for list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial input query. Only used when
+            initial query is using genomic free text or gnomad vcf format
         :return: List of accessions
         """
 
@@ -84,20 +92,29 @@ class Validator(ABC):
         :return: List of validation results containing invalid and valid results
         """
 
-    async def validate(self, classification: Classification) -> List[ValidationResult]:
+    async def validate(
+        self,
+        classification: Classification,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
+    ) -> List[ValidationResult]:
         """Get list of associated accessions for a classification. Use these accessions
         to perform validation checks (pos exists, accession is valid, reference sequence
         matches expected, etc). Gets list of validation results for a given
         classification
 
         :param classification: A classification for a list of tokens
+        :param input_assembly: Assembly used for initial input query
         :return: List of validation results containing invalid and valid results
         """
         errors = []
 
         try:
             # NC_ queries do not have gene tokens
-            accessions = await self.get_accessions(classification, errors)
+            accessions = await self.get_accessions(
+                classification, errors, input_assembly=input_assembly
+            )
         except IndexError:
             accessions = []
 
@@ -144,15 +161,23 @@ class Validator(ABC):
         return accessions
 
     async def get_genomic_accessions(
-        self, classification: Classification, errors: List
+        self,
+        classification: Classification,
+        errors: List,
+        input_assembly: Optional[
+            Union[ClinVarAssembly.GRCH37, ClinVarAssembly.GRCH38]
+        ] = None,
     ) -> List[str]:
         """Get genomic RefSeq accessions for variations with genomic reference sequence.
 
         :param classification: Classification for a list of tokens
         :param errors: List of errors
+        :param input_assembly: Assembly used for initial query
         :return: List of possible genomic RefSeq accessions for the variation
         """
-        accessions = await self.genomic_base.get_nc_accessions(classification)
+        accessions = await self.genomic_base.get_nc_accessions(
+            classification, input_assembly=input_assembly
+        )
         if not accessions:
             errors.append("No genomic accessions found")
         return accessions


### PR DESCRIPTION
close #490