### PR TITLE
fix: add condition when there are no valid results in /to_vrs

### DIFF
--- a/variation/to_vrs.py
+++ b/variation/to_vrs.py
@@ -136,6 +136,9 @@ class ToVRS(VRSRepresentation):
                 hgvs_dup_del_mode=HGVSDupDelModeOption.DEFAULT,
                 do_liftover=False,
             )
+        else:
+            translations = []
+            warnings = validation_summary.warnings
 
         if not translations:
             if untranslatable_returns_text and q and q.strip():


### PR DESCRIPTION
Close #500

Forgot to catch the case where there are no valid results. Fixes so that translations is defined