### PR TITLE
fix: _get_priority_translation_result using wrong variable

### DIFF
--- a/variation/normalize.py
+++ b/variation/normalize.py
@@ -103,9 +103,9 @@ class Normalize(ToVRSATILE):
                     key=lambda t: (t.og_ac.split(".")[0], int(t.og_ac.split(".")[1])),
                     reverse=True,
                 )
-                translation_result = translations[0]
+                translation_result = preferred_translations[0]
         elif len_preferred_translations == 1:
-            translation_result = translations[0]
+            translation_result = preferred_translations[0]
         else:
             translation_result = None
 


### PR DESCRIPTION
Close #502

- Was using `translations` when it should have been using `preferred_translations`