### PR TITLE
build: pin ga4gh.vrs dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ ruff = "==0.2.0"
 fastapi = "*"
 uvicorn = "*"
 pydantic = "==2.*"
-"ga4gh.vrs" = {version = "~=2.0.0a2", extras = ["extras"]}
+"ga4gh.vrs" = {version = "==2.0.0a2", extras = ["extras"]}
 gene-normalizer = "~=0.3.0.dev1"
 boto3 = "*"
 cool-seq-tool = "~=0.4.0.dev1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "pydantic ==2.*",
-    "ga4gh.vrs[extras] ~= 2.0.0a2",
+    "ga4gh.vrs[extras] == 2.0.0a2",
     "gene-normalizer ~=0.3.0.dev1",
     "boto3",
     "cool-seq-tool ~=0.4.0.dev1",

--- a/src/variation/version.py
+++ b/src/variation/version.py
@@ -1,2 +1,2 @@
 """Module for version of app"""
-__version__ = "0.8.1-dev0"
+__version__ = "0.8.1"


### PR DESCRIPTION
There were breaking changes in new versions. The API does not show all fields in VRS Variation. 