### PR TITLE
test: only check vrs ids on certain tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Create methods used throughout tests."""
 import asyncio
+import contextlib
 
 import pytest
 from cool_seq_tool.app import CoolSeqTool
@@ -93,7 +94,6 @@ def prpf8_ncbi_seq_loc():
         },
         "start": 1650628,
         "end": 1684867,
-        "id": "ga4gh:SL.1i49iv3wcBq7SaOA14cs1Kz7SR6DkCw1",
         "type": "SequenceLocation",
     }
 
@@ -129,9 +129,7 @@ def braf_v600e(braf_600loc):
 def vhl_reference_agree():
     """Create NP_000542.1:p.Pro61 fixture."""
     params = {
-        "id": "ga4gh:VA.RMmwTvhrPVwfMZ6knsf5zMWQn_F1ukYh",
         "location": {
-            "id": "ga4gh:SL.8TZYB8Oqqn93q07zrsNhvRW1JjNpaQXc",
             "end": 61,
             "start": 60,
             "sequenceReference": {
@@ -150,9 +148,7 @@ def vhl_reference_agree():
 def protein_insertion():
     """Create test fixture for NP protein insertion (CA645561585)."""
     params = {
-        "id": "ga4gh:VA.AOCCh_BU5wKkdgoDNqkORF_x4GQwWh1T",
         "location": {
-            "id": "ga4gh:SL.ciWb1ylkqUxiviU1djijiuYVZcgsnQnV",
             "end": 770,
             "start": 770,
             "sequenceReference": {
@@ -173,9 +169,7 @@ def protein_deletion_np_range():
     range for deletion.
     """
     params = {
-        "id": "ga4gh:VA.3Rk_RElDfX820edkQOHsTTYRogr0EMEY",
         "location": {
-            "id": "ga4gh:SL.kOTzy0aLlw0yqnmf29Zk8wh65zHQwere",
             "end": 759,
             "start": 754,
             "sequenceReference": {
@@ -199,9 +193,7 @@ def protein_deletion_np_range():
 def braf_v600e_genomic_sub():
     """Create test fixture for NC_000007.14:g.140753336A>T"""
     params = {
-        "id": "ga4gh:VA.LX3ooHBAiZdKY4RfTXcliUmkj48mnD_M",
         "location": {
-            "id": "ga4gh:SL.XutGzMvqbzN-vnxmPt2MJf7ehxmB0opi",
             "end": 140753336,
             "start": 140753335,
             "sequenceReference": {
@@ -264,7 +256,6 @@ def genomic_dup1_38_cn(genomic_dup1_seq_loc_not_normalized):
 def genomic_dup2_seq_loc_normalized():
     """Create genomic dup2 sequence location"""
     return {
-        "id": "ga4gh:SL.rVXa8TXm6WTEw-_Lom6A347Q45SB7CON",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -280,7 +271,6 @@ def genomic_dup2_38_cn(genomic_dup2_seq_loc_normalized):
     """Create test fixture for copy number count dup2 on GRCh38"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.C8WuNCba5AN1RoXK1enXgALlM1Qz6X6i",
         "location": genomic_dup2_seq_loc_normalized,
         "copies": 3,
     }
@@ -291,7 +281,6 @@ def genomic_dup2_38_cn(genomic_dup2_seq_loc_normalized):
 def genomic_del3_dup3_loc_not_normalized():
     """Create genomic del3 dup3 sequence location"""
     return {
-        "id": "ga4gh:SL.-zCp7JBaKQ0niPDueJkuCgQhRIQ50hKw",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -306,7 +295,6 @@ def genomic_del3_dup3_loc_not_normalized():
 def genomic_dup4_loc():
     """Create genomic dup4 sequence location"""
     return {
-        "id": "ga4gh:SL.o8sCaAaW2a2f_HsNBTsHOCnWRvIyru0y",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.-A1QmD_MatoqxvgVxBLZTONHz9-c7nQo",
@@ -321,7 +309,6 @@ def genomic_dup4_loc():
 def genomic_dup5_loc():
     """Create genomic dup5 sequence location"""
     return {
-        "id": "ga4gh:SL.O__pyYq_u7R__2NUbI3koxxkeCBL7WXq",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -336,7 +323,6 @@ def genomic_dup5_loc():
 def genomic_dup6_loc():
     """Create genomic dup6 sequence location"""
     return {
-        "id": "ga4gh:SL.Ls2wfxI-2V2OdMY5HHttwlSwgbpNf_j2",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -351,7 +337,6 @@ def genomic_dup6_loc():
 def genomic_del1_seq_loc():
     """Create genomic del1 sequence location"""
     return {
-        "id": "ga4gh:SL.zMba5wGtQWQmdFd70yEqMYszGoRaYX25",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX",
@@ -367,7 +352,6 @@ def genomic_del1_lse(genomic_del1_seq_loc):
     """Create a test fixture for genomic del LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.gztc0BFS6p5V1_QVnEYIJ6DwzZQeDCd2",
         "location": genomic_del1_seq_loc,
         "state": {
             "length": 0,
@@ -384,7 +368,6 @@ def genomic_del1_38_cn(genomic_del1_seq_loc):
     """Create test fixture for copy number count del1 on GRCh38"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.wRj3ZKNriLtPDVj0VlPaTCQfklj2ocGU",
         "location": genomic_del1_seq_loc,
         "copies": 1,
     }
@@ -395,7 +378,6 @@ def genomic_del1_38_cn(genomic_del1_seq_loc):
 def genomic_del2_seq_loc():
     """Create genomic del2 sequence location"""
     return {
-        "id": "ga4gh:SL.usVkXRvjfX0cEXLvP87Oi8eJJGyizjQF",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX",
@@ -411,7 +393,6 @@ def genomic_del2_lse(genomic_del2_seq_loc):
     """Create a test fixture for genomic del LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.9NmH0sRYerurt-CE6WlF9UaxZiujByIE",
         "location": genomic_del2_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -428,7 +409,6 @@ def genomic_del2_38_cn(genomic_del2_seq_loc):
     """Create test fixture for copy number count del1 on GRCh38"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.i7HRf9gge1HJKzazgvtinosa0bE3gHJu",
         "location": genomic_del2_seq_loc,
         "copies": 1,
     }
@@ -439,7 +419,6 @@ def genomic_del2_38_cn(genomic_del2_seq_loc):
 def genomic_del4_seq_loc():
     """Create genomic del4 sequence location"""
     return {
-        "id": "ga4gh:SL.bWbNmdT__ptImBwTAIYdyNfazhwvEtXD",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -454,7 +433,6 @@ def genomic_del4_seq_loc():
 def genomic_del5_seq_loc():
     """Create genomic del5 sequence location"""
     return {
-        "id": "ga4gh:SL.WDxMzftZLrwp2eQJrlasKuY4ns99wG0v",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -469,7 +447,6 @@ def genomic_del5_seq_loc():
 def genomic_del6_seq_loc():
     """Create genomic del6 sequence location"""
     return {
-        "id": "ga4gh:SL.TKIwU5OzGgOWIpnzAHfkCLB7vrKupKhD",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV",
@@ -484,7 +461,6 @@ def genomic_del6_seq_loc():
 def grch38_genomic_insertion_seq_loc():
     """Create test fixture for GRCh38 genomic insertion seq location"""
     return {
-        "id": "ga4gh:SL.oVzSkGhh3QJ0FAgihm-kNr9CJbF_7Ln2",
         "end": 39724743,
         "start": 39724731,
         "sequenceReference": {
@@ -499,7 +475,6 @@ def grch38_genomic_insertion_seq_loc():
 def grch38_genomic_insertion_variation(grch38_genomic_insertion_seq_loc):
     """Create a test fixture for NC_000017.10:g.37880993_37880994insGCTTACGTGATG"""
     params = {
-        "id": "ga4gh:VA.eorsJMgis9uDdRRPVd3srYofdPaM_xn2",
         "location": grch38_genomic_insertion_seq_loc,
         "state": {
             "length": 24,
@@ -528,7 +503,6 @@ def braf_amplification(braf_ncbi_seq_loc):
 def prpf8_amplification(prpf8_ncbi_seq_loc):
     """Create test fixture for PRPF8 Amplification"""
     params = {
-        "id": "ga4gh:CX.KH_rYvTqg5Hq0ysqbrh8JR20oeLYa7bk",
         "location": prpf8_ncbi_seq_loc,
         "copyChange": "efo:0030072",
         "type": "CopyNumberChange",
@@ -541,28 +515,53 @@ def genomic_del3_dup3_cn_38(genomic_del3_dup3_loc_not_normalized):
     """Create test fixture copy number variation for del/dup 3 on GRCh38"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.rPsK0krAHgmXhDZEw4fqymR0iDQa3UCJ",
         "location": genomic_del3_dup3_loc_not_normalized,
         "copies": 2,
     }
     return models.CopyNumberCount(**params)
 
 
-def assertion_checks(normalize_response, test_variation):
+def _delete_id(vrs_obj_dict):
+    """Delete ID property from VRS object"""
+    with contextlib.suppress(KeyError):
+        # Some fixtures have IDs for other tests
+        del vrs_obj_dict["id"]
+
+
+def assertion_checks(normalize_response, test_variation, check_vrs_id=False):
     """Check that normalize_response and test_variation are equal."""
     actual = normalize_response.variation.model_dump(exclude_none=True)
-    expected = test_variation.model_dump(exclude_none=True)
+    if not check_vrs_id:
+        assert actual.pop("id").startswith(("ga4gh:VA.", "ga4gh:CX", "ga4gh:CN."))
+        assert actual["location"].pop("id").startswith("ga4gh:SL.")
+
+    expected = test_variation.copy().model_dump(exclude_none=True)
+    if not check_vrs_id:
+        _delete_id(expected)
+        _delete_id(expected["location"])
+
     assert actual == expected, "variation"
 
 
-def cnv_assertion_checks(resp, test_fixture):
+def cnv_assertion_checks(resp, test_fixture, check_vrs_id=False):
     """Check that actual response for to copy number matches expected"""
     try:
         cnc = resp.copy_number_count
     except AttributeError:
         actual = resp.copy_number_change.model_dump(exclude_none=True)
+        prefix = "ga4gh:CX."
     else:
         actual = cnc.model_dump(exclude_none=True)
-    expected = test_fixture.model_dump(exclude_none=True)
+        prefix = "ga4gh:CN."
+
+    if not check_vrs_id:
+        assert actual.pop("id").startswith(prefix)
+        assert actual["location"].pop("id").startswith("ga4gh:SL.")
+
+    expected = test_fixture.copy().model_dump(exclude_none=True)
+    if not check_vrs_id:
+        _delete_id(expected)
+        _delete_id(expected["location"])
+
     assert actual == expected
     assert resp.warnings == []

--- a/tests/fixtures/translators.yml
+++ b/tests/fixtures/translators.yml
@@ -4,10 +4,8 @@ protein_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.PJu8CCaVzEyqXMAEcMNegyDWyvT_jzNn",
             "location":
               {
-                "id": "ga4gh:SL.EpHaD2ygDuPMvyURI9L4yetEwF3W0G7G",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -21,10 +19,8 @@ protein_substitution:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.4XBXAxSAk-WyAu5H0S1-plrk_SCTW1PO",
             "location":
               {
-                "id": "ga4gh:SL.ZA1XNKhCT_7m2UtmnYb8ZYOVS4eplMEK",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -38,10 +34,8 @@ protein_substitution:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.c-oRhbu7nDrBrSW2fPbFlDM15V6jiaho",
             "location":
               {
-                "id": "ga4gh:SL.gkevJbLNOScKXhxhzOZXiG3hW8zeyo-q",
                 "start": 599,
                 "end": 600,
                 "sequenceReference":
@@ -55,10 +49,8 @@ protein_substitution:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.3ex0cvKXjHbq8NLuitOAfVwSPzqZUFrR",
             "location":
               {
-                "id": "ga4gh:SL.Q4MXez2kHFPQqGJKLP8quVHAskuCrOAA",
                 "start": 599,
                 "end": 600,
                 "sequenceReference":
@@ -76,10 +68,8 @@ protein_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.4XBXAxSAk-WyAu5H0S1-plrk_SCTW1PO",
             "location":
               {
-                "id": "ga4gh:SL.ZA1XNKhCT_7m2UtmnYb8ZYOVS4eplMEK",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -100,10 +90,8 @@ protein_stop_gain:
       variations:
         [
           {
-            "id": "ga4gh:VA.KsGULBqRCUFNA89_9LErBWStMsBIXvlt",
             "location":
               {
-                "id": "ga4gh:SL.1qfXpIQd0Z4bAIpanqdhGpXmFd8_-Hb9",
                 "start": 184,
                 "end": 185,
                 "sequenceReference":
@@ -121,10 +109,8 @@ protein_stop_gain:
       variations:
         [
           {
-            "id": "ga4gh:VA.KsGULBqRCUFNA89_9LErBWStMsBIXvlt",
             "location":
               {
-                "id": "ga4gh:SL.1qfXpIQd0Z4bAIpanqdhGpXmFd8_-Hb9",
                 "start": 184,
                 "end": 185,
                 "sequenceReference":
@@ -142,10 +128,8 @@ protein_stop_gain:
       variations:
         [
           {
-            "id": "ga4gh:VA.KsGULBqRCUFNA89_9LErBWStMsBIXvlt",
             "location":
               {
-                "id": "ga4gh:SL.1qfXpIQd0Z4bAIpanqdhGpXmFd8_-Hb9",
                 "start": 184,
                 "end": 185,
                 "sequenceReference":
@@ -163,10 +147,8 @@ protein_stop_gain:
       variations:
         [
           {
-            "id": "ga4gh:VA.sGxJmxbzTpw6qqz2Kij3aXSZAPOge_G8",
             "location":
               {
-                "id": "ga4gh:SL.oGuWLVOr5Rdgradq5GJpMXEfcU7JQMDd",
                 "start": 1177,
                 "end": 1178,
                 "sequenceReference":
@@ -187,10 +169,8 @@ protein_reference_agree:
       variations:
         [
           {
-            "id": "ga4gh:VA.bBwytVniGA1kDz3eIh99tpaPR_RcJnEC",
             "location":
               {
-                "id": "ga4gh:SL.4jSgOyI22QGrwXaC3MaGeqF7A4JAg2-r",
                 "start": 153,
                 "end": 154,
                 "sequenceReference":
@@ -208,10 +188,8 @@ protein_reference_agree:
       variations:
         [
           {
-            "id": "ga4gh:VA.RMmwTvhrPVwfMZ6knsf5zMWQn_F1ukYh",
             "location":
               {
-                "id": "ga4gh:SL.8TZYB8Oqqn93q07zrsNhvRW1JjNpaQXc",
                 "start": 60,
                 "end": 61,
                 "sequenceReference":
@@ -229,10 +207,8 @@ protein_reference_agree:
       variations:
         [
           {
-            "id": "ga4gh:VA.149Sy4H4lHbL_l3Gy1G2z5hghz_1JNI2",
             "location":
               {
-                "id": "ga4gh:SL.-kQnuBxB3QrbbZBSTAoAbz0azJT821Sk",
                 "start": 54,
                 "end": 55,
                 "sequenceReference":
@@ -253,10 +229,8 @@ cdna_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.toS6q-Htpv6CpLPtbSo9E_zi8E7jFLqL",
             "location":
               {
-                "id": "ga4gh:SL.brDsydg4aD2TZqwqc3wZWKxWRx144A89",
                 "start": 1859,
                 "end": 1860,
                 "sequenceReference":
@@ -274,10 +248,8 @@ cdna_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.u4IphDRcnedzHjNGRx_yFJGD3JtOc_db",
             "location":
               {
-                "id": "ga4gh:SL.jRkp8fqzOE6Z1az_hmeDvmhzKVbCL6j-",
                 "start": 1859,
                 "end": 1860,
                 "sequenceReference":
@@ -300,10 +272,8 @@ genomic_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.ztz4yxckrW1j7YFSprOz_T9gwLdMc6LB",
             "location":
               {
-                "id": "ga4gh:SL.txr-jqnTLuz_3RVrPamx9cYniAFJg977",
                 "start": 140453135,
                 "end": 140453136,
                 "sequenceReference":
@@ -321,10 +291,8 @@ genomic_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.ztz4yxckrW1j7YFSprOz_T9gwLdMc6LB",
             "location":
               {
-                "id": "ga4gh:SL.txr-jqnTLuz_3RVrPamx9cYniAFJg977",
                 "start": 140453135,
                 "end": 140453136,
                 "sequenceReference":
@@ -342,10 +310,8 @@ genomic_substitution:
       variations:
         [
           {
-            "id": "ga4gh:VA.ztz4yxckrW1j7YFSprOz_T9gwLdMc6LB",
             "location":
               {
-                "id": "ga4gh:SL.txr-jqnTLuz_3RVrPamx9cYniAFJg977",
                 "start": 140453135,
                 "end": 140453136,
                 "sequenceReference":
@@ -366,10 +332,8 @@ cdna_reference_agree:
       variations:
         [
           {
-            "id": "ga4gh:VA.7UUAyVS_YyU4DLlP6RiVB268ZAy8zyyY",
             "location":
               {
-                "id": "ga4gh:SL.brDsydg4aD2TZqwqc3wZWKxWRx144A89",
                 "start": 1859,
                 "end": 1860,
                 "sequenceReference":
@@ -390,10 +354,8 @@ genomic_reference_agree:
       variations:
         [
           {
-            "id": "ga4gh:VA.kEu66A38U6zxpNXCXqc6Dmuezir1S6Tu",
             "location":
               {
-                "id": "ga4gh:SL.txr-jqnTLuz_3RVrPamx9cYniAFJg977",
                 "start": 140453135,
                 "end": 140453136,
                 "sequenceReference":
@@ -411,10 +373,8 @@ genomic_reference_agree:
       variations:
         [
           {
-            "id": "ga4gh:VA.JcLZ2KGaPcO1LEFYcjkmdAdo-CgsYhig",
             "location":
               {
-                "id": "ga4gh:SL.GXZ4UlQBqqfn29XEHoCllU7T7OIlkMVS",
                 "start": 140453135,
                 "end": 140453136,
                 "sequenceReference":
@@ -428,10 +388,8 @@ genomic_reference_agree:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.kEu66A38U6zxpNXCXqc6Dmuezir1S6Tu",
             "location":
               {
-                "id": "ga4gh:SL.txr-jqnTLuz_3RVrPamx9cYniAFJg977",
                 "start": 140453135,
                 "end": 140453136,
                 "sequenceReference":
@@ -452,10 +410,8 @@ protein_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.92P0i1m5gfT85HTuCXfintN2xFESjnB-",
             "location":
               {
-                "id": "ga4gh:SL.3Ap3XAZC0N5mHCgqbtdiwWOLjGFqbIep",
                 "end": 751,
                 "start": 746,
                 "sequenceReference":
@@ -473,10 +429,8 @@ protein_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.sm7fIUxzDjOAM2acs5f_7lz4vaTfRiZQ",
             "location":
               {
-                "id": "ga4gh:SL.ajzD3sda-U5t75BQFVSTbSjnpB_JIhGW",
                 "end": 776,
                 "start": 775,
                 "sequenceReference":
@@ -490,10 +444,8 @@ protein_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.r6Mt7QqHNHoCAP0BYkIdowDyo_Qd39HO",
             "location":
               {
-                "id": "ga4gh:SL.tQGMp_RLZJAzG7vHXSlzAe3PdWin8z6Y",
                 "end": 776,
                 "start": 775,
                 "sequenceReference":
@@ -507,10 +459,8 @@ protein_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.fYIoRKYHJB8h6G7U1T-hh6Cbhm7MNred",
             "location":
               {
-                "id": "ga4gh:SL.-TJqX5psxFSUnviBkufV7UndtWgiMWmf",
                 "end": 776,
                 "start": 775,
                 "sequenceReference":
@@ -524,10 +474,8 @@ protein_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.-B8y2zJ9sD1DF_Mz0HQWb0IJpBKNPjjF",
             "location":
               {
-                "id": "ga4gh:SL.eE9ee9uUCHtyeXFsTz2vSqJqy2f1IY-T",
                 "end": 776,
                 "start": 775,
                 "sequenceReference":
@@ -541,10 +489,8 @@ protein_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.iHwbQmIlhwkMjfPHESDwsnC8ZStgM7vq",
             "location":
               {
-                "id": "ga4gh:SL.8XQgBX5Olmnf96S7LhxaLyokCJ48PNcm",
                 "end": 776,
                 "start": 775,
                 "sequenceReference":
@@ -558,10 +504,8 @@ protein_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.l0EUqPsxH4Xg43ifUnsDTcB_cc9uTTOT",
             "location":
               {
-                "id": "ga4gh:SL.26fpCjMjI8UpsE-Vt0ADOfXbr-nfa4o4",
                 "end": 776,
                 "start": 775,
                 "sequenceReference":
@@ -582,10 +526,8 @@ cdna_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.GjDWdDFru9m7P-xYI9rTRxq3upJ4bI20",
             "location":
               {
-                "id": "ga4gh:SL.GIfFNwrm6SZMeaGqqnSobxtr0kZGgGAl",
                 "start": 2586,
                 "end": 2588,
                 "sequenceReference":
@@ -603,10 +545,8 @@ cdna_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.iQjEr3dKDMX1n2FWweAvIca6QWoDEOv9",
             "location":
               {
-                "id": "ga4gh:SL.hQQhl1lEB8c9jZYvMAlp7597fbIZhRzE",
                 "start": 1203,
                 "end": 1205,
                 "sequenceReference":
@@ -624,10 +564,8 @@ cdna_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.C8ciS2eoX3gN2pPixmhBi2o-u0r0RTN0",
             "location":
               {
-                "id": "ga4gh:SL.vPHmwGWL5xXR9fFJA4Ksv4s2ziyOf1nF",
                 "start": 827,
                 "end": 828,
                 "sequenceReference":
@@ -648,10 +586,8 @@ genomic_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.LkWsKQZid3ELe70zT_msZ0ML_OxHrjXO",
             "location":
               {
-                "id": "ga4gh:SL.XmwKDUQWWIGs3XDkRMvsTAH8gL_jey6E",
                 "start": 140453134,
                 "end": 140453136,
                 "sequenceReference":
@@ -669,10 +605,8 @@ genomic_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.LkWsKQZid3ELe70zT_msZ0ML_OxHrjXO",
             "location":
               {
-                "id": "ga4gh:SL.XmwKDUQWWIGs3XDkRMvsTAH8gL_jey6E",
                 "start": 140453134,
                 "end": 140453136,
                 "sequenceReference":
@@ -686,10 +620,8 @@ genomic_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.nWJAMU9SIxAjVXvf6hjy7CdOoRYpFKo-",
             "location":
               {
-                "id": "ga4gh:SL.ECL9ksWf3zttFix7aFjLk3oMGIT2r1T_",
                 "start": 140453134,
                 "end": 140453135,
                 "sequenceReference":
@@ -707,10 +639,8 @@ genomic_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.m3N5EEDcudS3thzXlwRDxiffKNgGukzv",
             "location":
               {
-                "id": "ga4gh:SL.acAqImEWvHwbUHaJi7L8yOyrSsc1DlW-",
                 "start": 10149937,
                 "end": 10149938,
                 "sequenceReference":
@@ -728,10 +658,8 @@ genomic_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.m3N5EEDcudS3thzXlwRDxiffKNgGukzv",
             "location":
               {
-                "id": "ga4gh:SL.acAqImEWvHwbUHaJi7L8yOyrSsc1DlW-",
                 "start": 10149937,
                 "end": 10149938,
                 "sequenceReference":
@@ -745,10 +673,8 @@ genomic_delins:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.4B9dWHwIS_Nek8yIC7rcVpsTyklMSmTK",
             "location":
               {
-                "id": "ga4gh:SL.mLNGrp5jlDKQRw3d4-XklOHh8DBGggMI",
                 "start": 10149937,
                 "end": 10149938,
                 "sequenceReference":
@@ -766,11 +692,9 @@ genomic_delins:
       variations:
         [
           {
-            "id": "ga4gh:VA.3Q0qa7xolRvjtdm7HsJdhwnARl40PZQC",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.ayQ3u0mtegVPCcfwjOtn1I1w8-kNm3jM",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -796,10 +720,8 @@ protein_deletion:
       variations:
         [
           {
-            "id": "ga4gh:VA.Cd6Z8tjYtsg60dO7xxaWDoTyXoS6SAc7",
             "location":
               {
-                "id": "ga4gh:SL.-l_WRD5XcRkY4frBSeQdljLrUTzYUAxE",
                 "end": 76,
                 "start": 75,
                 "sequenceReference":
@@ -823,10 +745,8 @@ protein_deletion:
       variations:
         [
           {
-            "id": "ga4gh:VA.PWbmz24TupE8h8g2Vw-gLWAjLiBw85N0",
             "location":
               {
-                "id": "ga4gh:SL.NzcGLbsfRAy4bLNS88kyjzUdqDGRVGd4",
                 "end": 84,
                 "start": 81,
                 "sequenceReference":
@@ -850,10 +770,8 @@ protein_deletion:
       variations:
         [
           {
-            "id": "ga4gh:VA.N7F0WqJs4dqp9ndh2YW7u0t6xRiHccpQ",
             "location":
               {
-                "id": "ga4gh:SL.RKZW47OI5rv2-9gU3rJKV9dMfq7BYT_u",
                 "start": 746,
                 "end": 751,
                 "sequenceReference":
@@ -872,10 +790,8 @@ protein_deletion:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.zyl9zFPjMMOtIdsfCDIUHvpyoQrDlRc7",
             "location":
               {
-                "id": "ga4gh:SL.3Ap3XAZC0N5mHCgqbtdiwWOLjGFqbIep",
                 "start": 746,
                 "end": 751,
                 "sequenceReference":
@@ -901,10 +817,8 @@ cdna_deletion:
       variations:
         [
           {
-            "id": "ga4gh:VA.ts4dehcMOYyN7u7CKO8fF4C80rZxALBY",
             "location":
               {
-                "id": "ga4gh:SL.8Buo3uzjQAY2kwIsaeiJgQLYqJc9wAVX",
                 "end": 2539,
                 "start": 2523,
                 "sequenceReference":
@@ -931,10 +845,8 @@ genomic_deletion:
       variations:
         [
           {
-            "id": "ga4gh:VA.oPjzfyjE7AmkHxvgVKFm3fr8Etu0Mp9b",
             "location":
               {
-                "id": "ga4gh:SL.cxEFtsg09n8eNXIWuRetrmWTUV1nm8_f",
                 "end": 10191487,
                 "start": 10191483,
                 "sequenceReference":
@@ -958,10 +870,8 @@ genomic_deletion:
       variations:
         [
           {
-            "id": "ga4gh:VA.oPjzfyjE7AmkHxvgVKFm3fr8Etu0Mp9b",
             "location":
               {
-                "id": "ga4gh:SL.cxEFtsg09n8eNXIWuRetrmWTUV1nm8_f",
                 "end": 10191487,
                 "start": 10191483,
                 "sequenceReference":
@@ -989,10 +899,8 @@ protein_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.AOCCh_BU5wKkdgoDNqkORF_x4GQwWh1T",
             "location":
               {
-                "id": "ga4gh:SL.ciWb1ylkqUxiviU1djijiuYVZcgsnQnV",
                 "end": 770,
                 "start": 770,
                 "sequenceReference":
@@ -1010,10 +918,8 @@ protein_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.5WCguhOtzU0gZGEW9mAlqtzROgJaEr5w",
             "location":
               {
-                "id": "ga4gh:SL.EpHaD2ygDuPMvyURI9L4yetEwF3W0G7G",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -1033,10 +939,8 @@ protein_insertion:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.Di6aHQPATSe_jG54fI2ZtLDtvrqWn1U0",
             "location":
               {
-                "id": "ga4gh:SL.Q4MXez2kHFPQqGJKLP8quVHAskuCrOAA",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -1056,10 +960,8 @@ protein_insertion:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.7ApUCILWJUCNIZcKq4oUurWEqyL3gyi9",
             "location":
               {
-                "id": "ga4gh:SL.gkevJbLNOScKXhxhzOZXiG3hW8zeyo-q",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -1079,10 +981,8 @@ protein_insertion:
             "type": "Allele",
           },
           {
-            "id": "ga4gh:VA.adBs3KK7T1yz8i9kfh1NFsGQQoaSLHJK",
             "location":
               {
-                "id": "ga4gh:SL.ZA1XNKhCT_7m2UtmnYb8ZYOVS4eplMEK",
                 "end": 600,
                 "start": 599,
                 "sequenceReference":
@@ -1109,10 +1009,8 @@ cdna_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.rUAwTHwBYQRPXbzBWTi6QbqoF1bAUjtn",
             "location":
               {
-                "id": "ga4gh:SL.-qRr3HfBajBTmzAVJPwyMb6wo9qfHqgm",
                 "end": 3134,
                 "start": 3131,
                 "sequenceReference":
@@ -1136,10 +1034,8 @@ cdna_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.I4EqcfOYhpPRgeNbwM1HhKqcA-gdmsrB",
             "location":
               {
-                "id": "ga4gh:SL.sFsPhPS3JCJkA_LObVXnrYeTSHp8GGT2",
                 "end": 3134,
                 "start": 3134,
                 "sequenceReference":
@@ -1160,11 +1056,9 @@ genomic_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.cY1c7lbwhHmg_b7cAxMpjQT6X-UYmcK9",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.7zWWbLgDc_VzA3G3oIdEu1v8EbKNd5Um",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1187,11 +1081,9 @@ genomic_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.cY1c7lbwhHmg_b7cAxMpjQT6X-UYmcK9",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.7zWWbLgDc_VzA3G3oIdEu1v8EbKNd5Um",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1210,11 +1102,9 @@ genomic_insertion:
               },
           },
           {
-            "id": "ga4gh:VA.PqonQkZk4h0bkVplJPZEBRUjUqY2fxXn",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.VGXyaPw8eXR1ut445bprXOX6WHmh-bXa",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1231,11 +1121,9 @@ genomic_insertion:
       variations:
         [
           {
-            "id": "ga4gh:VA.cxPRxlfPGzZD0pIdxu9EhAPhLZTzDNT0",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.LyA3prPbL8U0xJ3P6tO1w295QvRGxYnK",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1256,11 +1144,9 @@ genomic_deletion_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.1DiUzraiKZLJb8oF8ynARS816fthsJpV",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.bWbNmdT__ptImBwTAIYdyNfazhwvEtXD",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1277,11 +1163,9 @@ genomic_deletion_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.CJdXMZXSEE4hCIwjGxke4EWY7lMENYPj",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.2ORImLGRcezhWXDYI9sZvLwFGPDH9WKS",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1298,11 +1182,9 @@ genomic_deletion_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.q3OPPp2fWM5uM60RNHY_jDThCyxV3URW",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.aRKiRW6-lS9CCLfcPJpQIGihZqoIOCZ_",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1319,11 +1201,9 @@ genomic_deletion_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.vR12PHS1zCnoYUi9CSX3ZwhGG38xa-RA",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.N44ez-5301ZoNdLoiblcUvm__BS4-4Jv",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1343,11 +1223,9 @@ genomic_duplication:
       variations:
         [
           {
-            "id": "ga4gh:VA.CHNQRjx52keAGF5WcbvKORtfLiitZKE4",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.f0nAiaxOC3rPToQEYRRhbVBNO6HKutyc",
                 "sequenceReference":
                   {
                     "type": "SequenceReference",
@@ -1370,11 +1248,9 @@ genomic_duplication:
       variations:
         [
           {
-            "id": "ga4gh:VA.X_j-DHSSrgaCw1gfXzpIyG-I5e0PMGL3",
             "type": "Allele",
             "location":
               {
-                "id": "ga4gh:SL.1_LGkYC5Ytn5Vreye8dEPLM_uGKrvuAA",
                 "sequenceReference":
                   {
                     "type": "SequenceReference",
@@ -1400,11 +1276,9 @@ genomic_duplication_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.gsV4KrWvNQ_c0UT8M31mqa0HJ-IAHL8q",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.-zCp7JBaKQ0niPDueJkuCgQhRIQ50hKw",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1421,11 +1295,9 @@ genomic_duplication_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.6KvwSUu1Vp3FcC2VzbZxqpLAouOMCPi9",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.O__pyYq_u7R__2NUbI3koxxkeCBL7WXq",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1442,11 +1314,9 @@ genomic_duplication_ambiguous:
       variations:
         [
           {
-            "id": "ga4gh:CX.4JLs2ICAAvj5JgG0xHJk1voSKLb8gNQ9",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.o8sCaAaW2a2f_HsNBTsHOCnWRvIyru0y",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {
@@ -1466,11 +1336,9 @@ amplification:
       variations:
         [
           {
-            "id": "ga4gh:CX.89PECTeQjhhXnNW9yg24DheWOQMgmKk2",
             "type": "CopyNumberChange",
             "location":
               {
-                "id": "ga4gh:SL.uNBZoxhjhohl24VlIut-JxPJAGfJ7EQE",
                 "type": "SequenceLocation",
                 "sequenceReference":
                   {

--- a/tests/test_gnomad_vcf_to_protein.py
+++ b/tests/test_gnomad_vcf_to_protein.py
@@ -15,9 +15,7 @@ def test_handler(test_query_handler):
 def mmel1_l30m():
     """Create test fixture for MMEL1 L30M"""
     params = {
-        "id": "ga4gh:VA.OqqETz467CITELOZsYDukkab7JaOWiZf",
         "location": {
-            "id": "ga4gh:SL.Q7kfcqUWpIyEOgxcgPK1sRfgWPDv7zKA",
             "end": 30,
             "start": 29,
             "sequenceReference": {
@@ -36,9 +34,7 @@ def mmel1_l30m():
 def cdk11a_e314del():
     """Create test fixture for CDK11A Glu314del"""
     params = {
-        "id": "ga4gh:VA._CVnGazN6KosqrFnDx7kny-rb6yAZWtB",
         "location": {
-            "id": "ga4gh:SL.VqI6HuIFmm4XP3ocOTaobGxwqg4m6Ooi",
             "end": 321,
             "start": 308,
             "sequenceReference": {
@@ -62,9 +58,7 @@ def cdk11a_e314del():
 def protein_insertion2():
     """Create test fixture for LRP8 p.Gln25_Leu26insArg (CA860540)"""
     params = {
-        "id": "ga4gh:VA.5KWhsli69ac5zyoGf40Owu4CVNKy27So",
         "location": {
-            "id": "ga4gh:SL.I4c4NL0g3vBajHe44faZFQtrcqrbA14d",
             "end": 25,
             "start": 25,
             "sequenceReference": {
@@ -83,7 +77,6 @@ def protein_insertion2():
 def atad3a_loc():
     """Create test fixture for ATAD3A location"""
     return {
-        "id": "ga4gh:SL.xiP3uciIfJy_f44wNKCBvtsb35BC330Q",
         "end": 7,
         "start": 6,
         "sequenceReference": {
@@ -98,7 +91,6 @@ def atad3a_loc():
 def atad3a_i7v(atad3a_loc):
     """Create test fixture for ATAD3A Ile7Val"""
     params = {
-        "id": "ga4gh:VA.i_L_bjPfI4XLMIKmVklV6eDLKEl1f7PD",
         "location": atad3a_loc,
         "state": {"sequence": "V", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -110,7 +102,6 @@ def atad3a_i7v(atad3a_loc):
 def atad3a_i7t(atad3a_loc):
     """Create test fixture for ATAD3A Ile7Thr"""
     params = {
-        "id": "ga4gh:VA.C8QO-YAfG66yj7cEwjEhkEfSd-oCSKfc",
         "location": atad3a_loc,
         "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -122,7 +113,6 @@ def atad3a_i7t(atad3a_loc):
 def atad3a_i7m(atad3a_loc):
     """Create test fixture for ATAD3A Ile7Met"""
     params = {
-        "id": "ga4gh:VA.Fhmv3GK3bcIJRXOkigS9QNMzAWGW3WGa",
         "location": atad3a_loc,
         "state": {"sequence": "M", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -134,7 +124,6 @@ def atad3a_i7m(atad3a_loc):
 def braf_v600l(braf_600loc):
     """Create test fixture for BRAF Val600Leu."""
     params = {
-        "id": "ga4gh:VA.c6f1MPfquVRPZO46wVzCaGaU8QnXoHNN",
         "location": braf_600loc,
         "state": {"sequence": "L", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -146,7 +135,6 @@ def braf_v600l(braf_600loc):
 def braf_600_reference_agree(braf_600loc):
     """Create test fixture for BRAF Val600=."""
     params = {
-        "id": "ga4gh:VA.wS6kJNbPkRJDIWg8F4CjOMQ5mcJzD_X4",
         "location": braf_600loc,
         "state": {"sequence": "V", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -158,10 +146,8 @@ def braf_600_reference_agree(braf_600loc):
 def kras_g12d():
     """Fixture for KRAS G12D"""
     params = {
-        "id": "ga4gh:VA.CB571ja_KfZM_Hjn9zjjgV1an3tDWRcl",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:SL.OndkjmujtyUEZSjjCv0C-gpwnVbRgfj8",
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
@@ -181,10 +167,8 @@ def multi_nuc_sub_pos():
     positive strand (CA16042245)
     """
     params = {
-        "id": "ga4gh:VA.q_fhdDFpLT38y6TPU1EMtc2StwRGRVx0",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:SL.xcqWKkKU83UBmLq5Q1yrH6IyLvWkMcWk",
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
@@ -204,10 +188,8 @@ def multi_nuc_sub_neg():
     negative strand (CA1139661942)
     """
     params = {
-        "id": "ga4gh:VA.6K950oAyNXfIkPTmSHzX8f8wpNUroBGK",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:SL.RiO0HagK846MBCJZK7NVcDtlYPkdaXC4",
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
@@ -225,10 +207,8 @@ def multi_nuc_sub_neg():
 def delins_pos():
     """Create test fixture for the protein consequence of a delins on positive strand (CA645561524)"""
     params = {
-        "id": "ga4gh:VA.vBQ2TCfRHiG3ud_vqE88BNZEK7Qw28kg",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:SL.1btwhKRj0zZQwo-_CalR-WavTB019t-V",
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
@@ -246,10 +226,8 @@ def delins_pos():
 def delins_neg():
     """Create test fixture for the protein consequence of a delins on negative strand (ClinVar ID 1217291)"""
     params = {
-        "id": "ga4gh:VA.iSDLORgPGz21BetTQM5grpXyB3tIfZwl",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:SL.cmPqZ9vkQlmV_eWEW3MFKFeVtT_n1-yc",
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
@@ -285,7 +263,7 @@ async def test_substitution(
 
     # Reading Frame 2, Negative Strand
     resp = await test_handler.gnomad_vcf_to_protein("7-140753336-A-T")
-    assertion_checks(resp, braf_v600e)
+    assertion_checks(resp, braf_v600e, check_vrs_id=True)
     assert resp.gene_context
     assert resp.vrs_ref_allele_seq == "V"
     assert resp.warnings == []

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -45,7 +45,6 @@ def genomic_dup1_cx(genomic_dup1_seq_loc_not_normalized):
 def genomic_dup1_free_text_seq_loc_normalized():
     """Create genomic dup1 free text sequence location"""
     return {
-        "id": "ga4gh:SL.iyddzpD5lYY2Ayv87Np462l6P8QH7rH9",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.tpvbnWsfEGqip8gJQZnWJAF8-bWDUDKd",
@@ -60,7 +59,6 @@ def genomic_dup1_free_text_seq_loc_normalized():
 def genomic_dup1_free_text_seq_loc_not_normalized():
     """Create genomic dup1 free text sequence location"""
     return {
-        "id": "ga4gh:SL.L89XFOyAxF-wdQHXUV8OAAkx80Mltokc",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.tpvbnWsfEGqip8gJQZnWJAF8-bWDUDKd",
@@ -76,7 +74,6 @@ def genomic_dup1_free_text_lse(genomic_dup1_free_text_seq_loc_normalized):
     """Create a test fixture for genomic dup LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.muSdvI3Q126oFLKx3DrVkbzGfQ40kFhx",
         "location": genomic_dup1_free_text_seq_loc_normalized,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -93,7 +90,6 @@ def genomic_dup1_free_text_cn(genomic_dup1_free_text_seq_loc_not_normalized):
     """Create a test fixture for genomic dup copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.-97yN7Nq98gCVA7s0VslwuNdDVFLW6Af",
         "location": genomic_dup1_free_text_seq_loc_not_normalized,
         "copies": 3,
     }
@@ -105,7 +101,6 @@ def genomic_dup2_lse(genomic_dup2_seq_loc_normalized):
     """Create a test fixture for genomic dup LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.u4ffOvroo0SV1X13zWMA41EOdu1QSO9B",
         "location": genomic_dup2_seq_loc_normalized,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -122,7 +117,6 @@ def genomic_dup2_cx(genomic_dup2_seq_loc_normalized):
     """Create a test fixture for genomic dup copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.g4l6d1hb3Rd1slsYWSe4Z4x3ocKdCB3w",
         "location": genomic_dup2_seq_loc_normalized,
         "copyChange": "efo:0030070",
     }
@@ -133,7 +127,6 @@ def genomic_dup2_cx(genomic_dup2_seq_loc_normalized):
 def seq_loc_gt_100_bp():
     """Create seq loc for positions 33211290, 33211490 on NC_000023.11"""
     return {
-        "id": "ga4gh:SL.HYv7UB8dh8paRuy_Sb3g4sHQaTqJ3m8Q",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -149,7 +142,6 @@ def genomic_dup2_rle2(seq_loc_gt_100_bp):
     """Create a test fixture for genomic dup RSE where bp > 100."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.gOA4L7Juk4KcUZnq4CBOk32-gkuz5keM",
         "location": seq_loc_gt_100_bp,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -164,7 +156,6 @@ def genomic_dup2_rle2(seq_loc_gt_100_bp):
 def genomic_dup2_free_text_seq_loc():
     """Create genomic dup2 free text sequence location"""
     return {
-        "id": "ga4gh:SL.D4MxySRp4-wlbC3whkRZIhcfON2pKKgx",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.1DeZLYHMnd-smp3GDlpRxETb9_0AokO7",
@@ -180,7 +171,6 @@ def genomic_dup2_free_text_default(genomic_dup2_free_text_seq_loc):
     """Create a test fixture for genomic dup default and LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.rEgZI-6A3SdNKhqqNapVYlcF_mzUeUGg",
         "location": genomic_dup2_free_text_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -197,7 +187,6 @@ def genomic_dup2_free_text_cn(genomic_dup2_free_text_seq_loc):
     """Create a test fixture for genomic dup copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.Dg3jMd1lsFKpXiJAPfzrh_50PQM2g1C3",
         "location": genomic_dup2_free_text_seq_loc,
         "copies": 3,
     }
@@ -209,7 +198,6 @@ def genomic_dup3_cx(genomic_del3_dup3_loc_not_normalized):
     """Create a test fixture for genomic dup copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.gsV4KrWvNQ_c0UT8M31mqa0HJ-IAHL8q",
         "location": genomic_del3_dup3_loc_not_normalized,
         "copyChange": "efo:0030070",
     }
@@ -220,7 +208,6 @@ def genomic_dup3_cx(genomic_del3_dup3_loc_not_normalized):
 def genomic_dup3_free_text_subject():
     """Create test fixture for genomic dup3 free text location"""
     return {
-        "id": "ga4gh:SL.OFGMAP2dUKRbBk5Q3MroJzbvcjEJQfyZ",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -236,7 +223,6 @@ def genomic_dup3_free_text_cx(genomic_dup3_free_text_subject):
     """Create a test fixture for genomic dup copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.qf8-7kAverUttRlwQBXFPeuVq5o2-bVa",
         "location": genomic_dup3_free_text_subject,
         "copyChange": "efo:0030070",
     }
@@ -248,7 +234,6 @@ def genomic_dup3_free_text_cn(genomic_dup3_free_text_subject):
     """Create a test fixture for genomic dup copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.3yNGNFGVAO5DGc0sPTThdUwTfJLPyWfM",
         "location": genomic_dup3_free_text_subject,
         "copies": 4,
     }
@@ -260,7 +245,6 @@ def genomic_dup4_cx(genomic_dup4_loc):
     """Create a test fixture for genomic dup copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.4JLs2ICAAvj5JgG0xHJk1voSKLb8gNQ9",
         "location": genomic_dup4_loc,
         "copyChange": "efo:0030070",
     }
@@ -272,7 +256,6 @@ def genomic_dup4_cn(genomic_dup4_loc):
     """Create a test fixture for genomic dup copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.KqbQewUgZYfmottbgn1xYq58DiPVU5SZ",
         "location": genomic_dup4_loc,
         "copies": 3,
     }
@@ -283,7 +266,6 @@ def genomic_dup4_cn(genomic_dup4_loc):
 def genomic_dup4_free_text_subject():
     """Create test fixture for genomic dup4 free text location"""
     return {
-        "id": "ga4gh:SL.SIeDb2iPT5pM-1SDKM9ew8NjzZAgF8nb",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7",
@@ -299,7 +281,6 @@ def genomic_dup4_free_text_cx(genomic_dup4_free_text_subject):
     """Create a test fixture for genomic dup copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.A7iAltzEFjlPJPCBfdMwjsis-vt51o3L",
         "location": genomic_dup4_free_text_subject,
         "copyChange": "efo:0030070",
     }
@@ -311,7 +292,6 @@ def genomic_dup4_free_text_cn(genomic_dup4_free_text_subject):
     """Create a test fixture for genomic dup copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.hnSfHkympkuTJQlfJHjHUqvUMU-EM2_Z",
         "location": genomic_dup4_free_text_subject,
         "copies": 3,
     }
@@ -323,7 +303,6 @@ def genomic_dup5_cx(genomic_dup5_loc):
     """Create a test fixture for genomic dup5 copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.6KvwSUu1Vp3FcC2VzbZxqpLAouOMCPi9",
         "location": genomic_dup5_loc,
         "copyChange": "efo:0030070",
     }
@@ -335,7 +314,6 @@ def genomic_dup5_cn(genomic_dup5_loc):
     """Create a test fixture for genomic dup5 copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.nlDhmSyOYeLZ8Fv2_F0niIraPbHUvpOU",
         "location": genomic_dup5_loc,
         "copies": 3,
     }
@@ -347,7 +325,6 @@ def genomic_dup6_cx(genomic_dup6_loc):
     """Create a test fixture for genomic dup copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.yMUFkF1QBwq3mA2tUS8wTLH3--dEHJJD",
         "location": genomic_dup6_loc,
         "copyChange": "efo:0030070",
     }
@@ -371,7 +348,6 @@ def genomic_del1_lse(genomic_del1_seq_loc):
     """Create a test fixture for genomic del LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.gztc0BFS6p5V1_QVnEYIJ6DwzZQeDCd2",
         "location": genomic_del1_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -388,7 +364,6 @@ def genomic_del1_cx(genomic_del1_seq_loc):
     """Create a test fixture for genomic del copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.LWRBNtBgcETMXEKezrr7WUPjO9WoOaqL",
         "location": genomic_del1_seq_loc,
         "copyChange": "efo:0030064",
     }
@@ -400,7 +375,6 @@ def genomic_del1_rle(genomic_del1_seq_loc):
     """Create a test fixture for genomic del RSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.Kg0FrJBjKRtIDsIKO0LxAwOPiXIOowoc",
         "location": genomic_del1_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -415,7 +389,6 @@ def genomic_del1_rle(genomic_del1_seq_loc):
 def genomic_del1_free_text_seq_loc():
     """Create genomic del1 free text sequence location"""
     return {
-        "id": "ga4gh:SL.072FoTQ7ZWLfOOOdyTI3Vj5pc2qwDii6",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.xBKOKptLLDr-k4hTyCetvARn16pDS_rW",
@@ -431,7 +404,6 @@ def genomic_del1_free_text_lse(genomic_del1_free_text_seq_loc):
     """Create a test fixture for genomic del LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.8xbobLhnVeBLQ6ANUur7BcPNdXrLsSja",
         "location": genomic_del1_free_text_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -448,7 +420,6 @@ def genomic_del1_free_text_cn(genomic_del1_free_text_seq_loc):
     """Create a test fixture for genomic del copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.OakJW5ITpO4m1ffP4tGoBK72_IIqEBM6",
         "location": genomic_del1_free_text_seq_loc,
         "copies": 1,
     }
@@ -460,7 +431,6 @@ def genomic_del1_free_text_rle(genomic_del1_free_text_seq_loc):
     """Create a test fixture for genomic del RSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.XZMMF_xhn76bLMxN5RnewNgrXkYuK-ni",
         "location": genomic_del1_free_text_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -476,7 +446,6 @@ def genomic_del2_lse(genomic_del2_seq_loc):
     """Create a test fixture for genomic del LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.9NmH0sRYerurt-CE6WlF9UaxZiujByIE",
         "location": genomic_del2_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -493,7 +462,6 @@ def genomic_del2_lse2(seq_loc_gt_100_bp):
     """Create a test fixture for genomic del LSE where bp > 100."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.1_cveYe6e74MEUt8EdTQmEtW5t6nA5bU",
         "location": seq_loc_gt_100_bp,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -510,7 +478,6 @@ def genomic_del2_cx(genomic_del2_seq_loc):
     """Create a test fixture for genomic del copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.xOZeCpcgWTj-xTYJdIeXbRy8h48qfbQ5",
         "location": genomic_del2_seq_loc,
         "copyChange": "efo:0030069",
     }
@@ -522,7 +489,6 @@ def genomic_del2_rle(genomic_del2_seq_loc):
     """Create a test fixture for genomic del RSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.J6hHiLw-qq27H8CZ8aQRdJwBGHqd3BvB",
         "location": genomic_del2_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -537,7 +503,6 @@ def genomic_del2_rle(genomic_del2_seq_loc):
 def genomic_del2_free_text_seq_loc():
     """Create genomic del2 free text sequence location"""
     return {
-        "id": "ga4gh:SL.b06yJ2UPwSSo-4bmYE8ZqHkDfo6_KZuu",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.xBKOKptLLDr-k4hTyCetvARn16pDS_rW",
@@ -553,7 +518,6 @@ def genomic_del2_free_text_default(genomic_del2_free_text_seq_loc):
     """Create a test fixture for genomic del default and LSE."""
     params = {
         "type": "Allele",
-        "id": "ga4gh:VA.ZmmZ_3it-b0nl8pdxaIG5ROYwTYhhRfk",
         "location": genomic_del2_free_text_seq_loc,
         "state": {
             "type": "ReferenceLengthExpression",
@@ -570,7 +534,6 @@ def genomic_del2_free_text_cnv(genomic_del2_free_text_seq_loc):
     """Create a test fixture for genomic del CNV."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.DdDmUshRGGSxugHHqGI8agdffFmvwjFm",
         "location": genomic_del2_free_text_seq_loc,
         "copies": 1,
     }
@@ -582,7 +545,6 @@ def genomic_del3_cx(genomic_del3_dup3_loc_not_normalized):
     """Create a test fixture for genomic del copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.BWTPMUku6nwuWhULJogKyxEk64XDIYGm",
         "location": genomic_del3_dup3_loc_not_normalized,
         "copyChange": "efo:0030067",
     }
@@ -593,7 +555,6 @@ def genomic_del3_cx(genomic_del3_dup3_loc_not_normalized):
 def genomic_del3_free_text_subject():
     """Create test fixture for genomic del3 free text location"""
     return {
-        "id": "ga4gh:SL.5_TZXeJhFejft3jmfkqdNutVO2tenSeB",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
@@ -609,7 +570,6 @@ def genomic_del3_free_text_cx(genomic_del3_free_text_subject):
     """Create a test fixture for genomic del copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.SS7Ywi8yq2fb7acAdbs1a-H6ELw4QxLy",
         "location": genomic_del3_free_text_subject,
         "copyChange": "efo:0030067",
     }
@@ -621,7 +581,6 @@ def genomic_del3_free_text_cn(genomic_del3_free_text_subject):
     """Create a test fixture for genomic del copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.nYr-z9MXHGx8p3hP0Wht3WDw0gju9QDL",
         "location": genomic_del3_free_text_subject,
         "copies": 2,
     }
@@ -633,7 +592,6 @@ def genomic_del4_cx(genomic_del4_seq_loc):
     """Create a test fixture for genomic del copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.1DiUzraiKZLJb8oF8ynARS816fthsJpV",
         "location": genomic_del4_seq_loc,
         "copyChange": "efo:0030067",
     }
@@ -645,7 +603,6 @@ def genomic_del4_cn(genomic_del4_seq_loc):
     """Create a test fixture for genomic del copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.6RKML7P4zTx1U8EpJ1q7L23OXDEKFihS",
         "location": genomic_del4_seq_loc,
         "copies": 1,
     }
@@ -656,7 +613,6 @@ def genomic_del4_cn(genomic_del4_seq_loc):
 def genomic_del4_free_text_subject():
     """Create test fixture for genomic del4 free text location"""
     return {
-        "id": "ga4gh:SL.ebOW5blAtyPPVH512rIYi6cGsyKI2990",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g",
@@ -672,7 +628,6 @@ def genomic_del4_free_text_cx(genomic_del4_free_text_subject):
     """Create a test fixture for genomic del copy number change."""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.iI0rwBfPht6XCBhYPsfWUUbTwDIRycFi",
         "location": genomic_del4_free_text_subject,
         "copyChange": "efo:0030067",
     }
@@ -684,7 +639,6 @@ def genomic_del4_free_text_cn(genomic_del4_free_text_subject):
     """Create a test fixture for genomic del copy number count."""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.ps-GD4HSeJZjxnS1dhQrn4ntJFaA97a3",
         "location": genomic_del4_free_text_subject,
         "copies": 1,
     }
@@ -695,9 +649,7 @@ def genomic_del4_free_text_cn(genomic_del4_free_text_subject):
 def genomic_uncertain_del_2():
     """Create a genomic uncertain deletion on chr 2 test fixture."""
     params = {
-        "id": "ga4gh:CX.q3OPPp2fWM5uM60RNHY_jDThCyxV3URW",
         "location": {
-            "id": "ga4gh:SL.aRKiRW6-lS9CCLfcPJpQIGihZqoIOCZ_",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g",
@@ -716,9 +668,7 @@ def genomic_uncertain_del_2():
 def genomic_uncertain_del_y():
     """Create a genomic uncertain deletion on chr Y test fixture."""
     params = {
-        "id": "ga4gh:CX.vR12PHS1zCnoYUi9CSX3ZwhGG38xa-RA",
         "location": {
-            "id": "ga4gh:SL.N44ez-5301ZoNdLoiblcUvm__BS4-4Jv",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -738,7 +688,6 @@ def genomic_del5_cn_var(genomic_del5_seq_loc):
     """Create genomic del5 copy number count"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.B2qGS47pqvyvBjFRQEj3MjdsqfXpnhhC",
         "location": genomic_del5_seq_loc,
         "copies": 3,
     }
@@ -750,7 +699,6 @@ def genomic_del5_cx_var(genomic_del5_seq_loc):
     """Create genomic del5 copy number change"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.oUhToHxDGpH5NkuFaQmKTmbijF9z_Esb",
         "location": genomic_del5_seq_loc,
         "copyChange": "efo:0030067",
     }
@@ -762,7 +710,6 @@ def genomic_del6_cx_var(genomic_del6_seq_loc):
     """Create genomic del6 copy number change"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.gmwszbknrMmklvVuu2yOqu5nOKV_fp72",
         "location": genomic_del6_seq_loc,
         "copyChange": "efo:0030067",
     }
@@ -774,7 +721,6 @@ def genomic_del6_cn_var(genomic_del6_seq_loc):
     """Create genomic del6 copy number count"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.CZEc44pX7Dh9yJARvvz6EW9oQvgkbwYf",
         "location": genomic_del6_seq_loc,
         "copies": 1,
     }
@@ -807,44 +753,44 @@ async def test_genomic_dup1(
     # https://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/allele?hgvsOrDescriptor=NC_000003.12%3Ag.49531262dup
     q = "NC_000003.12:g.49531262dup"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup1_lse)
+    assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup1_lse)
+    assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup1_38_cn)
+    assertion_checks(resp, genomic_dup1_38_cn, check_vrs_id=True)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030072,
     )
-    assertion_checks(resp, genomic_dup1_cx)
+    assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
-    assertion_checks(resp, genomic_dup1_lse)
+    assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True)
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup1_lse)
+    assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup1_38_cn)
+    assertion_checks(resp, genomic_dup1_38_cn, check_vrs_id=True)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030072,
     )
-    assertion_checks(resp, genomic_dup1_cx)
+    assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
-    assertion_checks(resp, genomic_dup1_lse)
+    assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True)
 
     # Free Text
     for q in ["DAG1 g.49568695dup", "DAG1 g.49531262dup"]:  # 37  # 38

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -20,9 +20,7 @@ def test_handler(test_query_handler):
 def dis3_p63a():
     """Create DIS3 P63A test fixture."""
     params = {
-        "id": "ga4gh:VA.HSJaPh-tYk0SxPPenZ2wP9db1sTWPiEb",
         "location": {
-            "id": "ga4gh:SL.2mNB74aM_uxrSpjVQ66vJv4l60QqLw92",
             "end": 63,
             "start": 62,
             "sequenceReference": {
@@ -41,9 +39,7 @@ def dis3_p63a():
 def tp53_g262c():
     """Create TP53 G262C test fixture."""
     params = {
-        "id": "ga4gh:VA.-ZtQ7h9wnK9RgVtd7YuiISNh80Mpp4c_",
         "location": {
-            "id": "ga4gh:SL.NUBjoy9wz7qcu-eM7vDEfm2oT0OBqEhu",
             "start": 261,
             "end": 262,
             "sequenceReference": {
@@ -62,9 +58,7 @@ def tp53_g262c():
 def vhl():
     """Create VHL Tyr185Ter fixture."""
     params = {
-        "id": "ga4gh:VA.KsGULBqRCUFNA89_9LErBWStMsBIXvlt",
         "location": {
-            "id": "ga4gh:SL.1qfXpIQd0Z4bAIpanqdhGpXmFd8_-Hb9",
             "end": 185,
             "start": 184,
             "sequenceReference": {
@@ -83,9 +77,7 @@ def vhl():
 def nm_004448_cdna_delins():
     """Create test fixture for NM_004448.4:c.2326_2327delinsCT."""
     params = {
-        "id": "ga4gh:VA.higf2Phdt6HsJIEFKtaKEb5EbTZP9tLX",
         "location": {
-            "id": "ga4gh:SL.voK3jkwJiGfUsGVm8P_A0claqeI35Jnv",
             "end": 2502,
             "start": 2500,
             "sequenceReference": {
@@ -104,9 +96,7 @@ def nm_004448_cdna_delins():
 def nm_000551():
     """Create test fixture for NM_000551.4:c.615delinsAA."""
     params = {
-        "id": "ga4gh:VA.MseO0j0sgMt73Jdzawul0JKsxFrJWODv",
         "location": {
-            "id": "ga4gh:SL.dFTM865y_W2iM6IPaKhW8E2ezHeo446u",
             "end": 685,
             "start": 684,
             "sequenceReference": {
@@ -125,7 +115,6 @@ def nm_000551():
 def braf_cdna_seq_loc():
     """Create test fixture for BRAF V600E cDNA representation sequence location"""
     return {
-        "id": "ga4gh:SL.d6fchgxsIiR1R_4IY2lBAhE1wb9zVtrp",
         "end": 2025,
         "start": 2024,
         "sequenceReference": {
@@ -140,7 +129,6 @@ def braf_cdna_seq_loc():
 def braf_v600e_nucleotide(braf_cdna_seq_loc):
     """Create a test fixture for BRAF V600E MANE select nucleotide hgvs."""
     params = {
-        "id": "ga4gh:VA.pL0tb7_iYp9A_opzwFMxRAPg6gTM_9A-",
         "location": braf_cdna_seq_loc,
         "state": {"sequence": "A", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -152,7 +140,6 @@ def braf_v600e_nucleotide(braf_cdna_seq_loc):
 def cdna_reference_agree(braf_cdna_seq_loc):
     """Create test fixture for NM_004333.4:c.1799=."""
     params = {
-        "id": "ga4gh:VA.itm3XgekfKho2tZq0L_mzocuyHrx4i6c",
         "location": braf_cdna_seq_loc,
         "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
         "type": "Allele",
@@ -164,9 +151,7 @@ def cdna_reference_agree(braf_cdna_seq_loc):
 def protein_delins():
     """Create test fixture for protein delins."""
     params = {
-        "id": "ga4gh:VA.J291lhv1vb2iu5fti8SSymq2_dWjYvN4",
         "location": {
-            "id": "ga4gh:SL.RKZW47OI5rv2-9gU3rJKV9dMfq7BYT_u",
             "end": 751,
             "start": 746,
             "sequenceReference": {
@@ -187,9 +172,7 @@ def cdna_deletion():
     sequence.
     """
     params = {
-        "id": "ga4gh:VA.-It83ZpjGFmgUvRk4i65-YJyD_zFWG4e",
         "location": {
-            "id": "ga4gh:SL.5GI6gputEL8E1NDu5kxbs3smO1JO-d1a",
             "end": 2453,
             "start": 2437,
             "sequenceReference": {
@@ -215,9 +198,7 @@ def genomic_deletion():
     (CA915940709)
     """
     params = {
-        "id": "ga4gh:VA.HUI0n5I7cmo1FqIxVLUo9edaRR5S_kME",
         "location": {
-            "id": "ga4gh:SL.jbutnbFRaj3Y6XQexjkN12Bd7HbWlloG",
             "end": 10146528,
             "start": 10146524,
             "sequenceReference": {
@@ -241,9 +222,7 @@ def genomic_deletion():
 def cdna_insertion():
     """Create test fixture for coding DNA insertion."""
     params = {
-        "id": "ga4gh:VA.-X8kNU4aUF3MUaBkGD_G_Lusl7vuqcgg",
         "location": {
-            "id": "ga4gh:SL.5sH0Wh00jrGB9DUlIxJUSPZ_ZraTlJ9p",
             "end": 2160,
             "start": 2160,
             "sequenceReference": {
@@ -262,9 +241,7 @@ def cdna_insertion():
 def genomic_insertion():
     """Create a gene insertion test fixture."""
     params = {
-        "id": "ga4gh:VA.7wTialdnDHIG9DTDtJAxERngeDUGCyNk",
         "location": {
-            "id": "ga4gh:SL.EMMJdP_rekeHOpIVVHWJSutPXdsjQqQ0",
             "end": 2500,
             "start": 2488,
             "sequenceReference": {
@@ -288,9 +265,7 @@ def genomic_insertion():
 def genomic_substitution():
     """Create a gene insertion test fixture."""
     params = {
-        "id": "ga4gh:VA.6KE54LHahQUK8rWz_dp1iU_aliXqW93B",
         "location": {
-            "id": "ga4gh:SL.qW8hZuSITudo3OlBahEwI-dSIvRKN9jQ",
             "end": 2630,
             "start": 2629,
             "sequenceReference": {
@@ -309,9 +284,7 @@ def genomic_substitution():
 def gnomad_vcf_genomic_sub_mnv():
     """Create a genomic substitution mnv test fixture for 5-112175770-GGAA-AGAA."""
     params = {
-        "id": "ga4gh:VA.naygzq3x2gWaX4NfCXcT5aJyxaGKAwZ3",
         "location": {
-            "id": "ga4gh:SL.L0moV8BjwdeSYkLsxLPhkJLG85x3hkKb",
             "end": 112840073,
             "start": 112840072,
             "sequenceReference": {
@@ -330,9 +303,7 @@ def gnomad_vcf_genomic_sub_mnv():
 def genomic_sub_grch38():
     """Create a genomic substitution GRCh38 test fixture."""
     params = {
-        "id": "ga4gh:VA.OvEfBRaS34JkfM0_ZHJVDQEjqtwzyjyp",
         "location": {
-            "id": "ga4gh:SL.ZCgOjF-_T0EOBXGc-6yICYui-jgFzJfY",
             "end": 55181378,
             "start": 55181377,
             "sequenceReference": {
@@ -351,9 +322,7 @@ def genomic_sub_grch38():
 def grch38_braf_genom_reference_agree():
     """Create a genomic reference agree GRCh38 test fixture for BRAF."""
     params = {
-        "id": "ga4gh:VA.J8DRaIofpFLaS3HE_C1xGLHoWje5INuQ",
         "location": {
-            "id": "ga4gh:SL.XutGzMvqbzN-vnxmPt2MJf7ehxmB0opi",
             "end": 140753336,
             "start": 140753335,
             "sequenceReference": {
@@ -372,9 +341,7 @@ def grch38_braf_genom_reference_agree():
 def grch38_genomic_delins1():
     """Create a test fixture for NC_000007.13:g.140453135_140453136delinsAT."""
     params = {
-        "id": "ga4gh:VA.nojfgZgtcwQ9Ylm0GuBuGnUT7Ug-_AKX",
         "location": {
-            "id": "ga4gh:SL.jW40gDuxQ9chCROKZs12FE7cHlX538EU",
             "end": 140753336,
             "start": 140753334,
             "sequenceReference": {
@@ -393,9 +360,7 @@ def grch38_genomic_delins1():
 def grch38_genomic_delins2():
     """Create a test fixture for NC_000003.12:g.10149938delinsAA."""
     params = {
-        "id": "ga4gh:VA.m3N5EEDcudS3thzXlwRDxiffKNgGukzv",
         "location": {
-            "id": "ga4gh:SL.acAqImEWvHwbUHaJi7L8yOyrSsc1DlW-",
             "start": 10149937,
             "end": 10149938,
             "sequenceReference": {
@@ -414,9 +379,7 @@ def grch38_genomic_delins2():
 def genomic_delins_gene():
     """Create a test fixture for BRAF g.140453135_140453136delinsAT (CA16602419)."""
     params = {
-        "id": "ga4gh:VA.oEPIg5_z6DZXl2ak6EQWzyIrDB1j5ylc",
         "location": {
-            "id": "ga4gh:SL.mD0_LS4ja0LTofG0ovgdxfbIv5ho8huY",
             "start": 2024,
             "end": 2026,
             "sequenceReference": {
@@ -439,9 +402,7 @@ def gnomad_vcf_genomic_delins1():
     allele?hgvsOrDescriptor=NM_000249.3%3Ac.489_498delinsGAGGCTTT
     """
     params = {
-        "id": "ga4gh:VA.k08iD4Yuq6YE2TGJDdk-8ZGI1N7q17NI",
         "location": {
-            "id": "ga4gh:SL.eHVQX0JhZML5VLIx_1Pn7biJCq7QmSQv",
             "start": 37008848,
             "end": 37008858,
             "sequenceReference": {
@@ -460,9 +421,7 @@ def gnomad_vcf_genomic_delins1():
 def gnomad_vcf_genomic_delins2():
     """Create a test fixture for 16-68846036-AG-TGAGTTT (CA396459910)"""
     params = {
-        "id": "ga4gh:VA.FRahr9wBmzpiO9mWEvU0HuLln9VL56UO",
         "location": {
-            "id": "ga4gh:SL.jZ6Tcqgap6uclFwtcAQfWIUWTz8-mBuj",
             "start": 68812132,
             "end": 68812134,
             "sequenceReference": {
@@ -481,9 +440,7 @@ def gnomad_vcf_genomic_delins2():
 def gnomad_vcf_genomic_delins3():
     """Create a test fixture for X-70350063-AG-AGGCAGCGCATAAAGCGCATTCTCCG"""
     params = {
-        "id": "ga4gh:VA.g2Lk1KFnr5zaMINhYI98tvHTsA8YVLVw",
         "location": {
-            "id": "ga4gh:SL.B_U4dRIuJb_rHIMBWajTHkGdb_yTZyZZ",
             "start": 71130213,
             "end": 71130215,
             "sequenceReference": {
@@ -507,9 +464,7 @@ def gnomad_vcf_genomic_delins3():
 def gnomad_vcf_genomic_delins4():
     """Create a test fixture for 1-55509715-AC-A"""
     params = {
-        "id": "ga4gh:VA.0zpgAsfWgv-MVZvHyg6kloySRIuTnLtz",
         "location": {
-            "id": "ga4gh:SL.JWTBfRuZF52vff0NDPeMcuwJ2-BrAszw",
             "end": 55044045,
             "start": 55044042,
             "sequenceReference": {
@@ -533,10 +488,8 @@ def gnomad_vcf_genomic_delins4():
 def gnomad_vcf_genomic_delins5():
     """Create test fixture for 17-7578455-CGCGG-CGCG (CA497925643)"""
     params = {
-        "id": "ga4gh:VA.2MWzLByOm1h0sOgwUM-7UCemXWj5q66c",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:SL.YHVgy44d-HtZibm08DlcHwCthT8oALxE",
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
@@ -559,7 +512,7 @@ def gnomad_vcf_genomic_delins5():
 async def test_protein_substitution(test_handler, braf_v600e, dis3_p63a, tp53_g262c):
     """Test that protein substitutions normalize correctly."""
     resp = await test_handler.normalize("     BRAF      V600E    ")
-    assertion_checks(resp, braf_v600e)
+    assertion_checks(resp, braf_v600e, check_vrs_id=True)
 
     resp = await test_handler.normalize("NP_004324.2:p.Val600Glu")
     assertion_checks(resp, braf_v600e)
@@ -895,7 +848,7 @@ async def test_amplification(test_handler, braf_amplification, prpf8_amplificati
     """Test that amplification normalizes correctly."""
     q = "BRAF Amplification"
     resp = await test_handler.normalize(q)
-    assertion_checks(resp, braf_amplification)
+    assertion_checks(resp, braf_amplification, check_vrs_id=True)
 
     # Gene with > 1 sequence location
     q = "PRPF8 AMPLIFICATION"
@@ -917,7 +870,7 @@ async def test_valid_queries(test_handler):
     resp = await test_handler.normalize("NC_000002.12:g.73448098_73448100delCTC")
     assert resp
     assert resp.variation.state.sequence.root == "CTC"
-    assert resp.variation.id == "ga4gh:VA.7Un0qQ6Ksg7hKCTt3xKR8VGEQuRU4jH_"
+    assert resp.variation.id.startswith("ga4gh:VA.")
 
     # Test ambiguous IUPAC code N
     for q in [

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -87,8 +87,13 @@ async def translator_checks(
                 vr, []
             )
             vrs_variation = translation_result.vrs_variation
+            assert vrs_variation.pop("id").startswith(
+                ("ga4gh:VA.", "ga4gh:CX", "ga4gh:CN.")
+            )
+            assert vrs_variation["location"].pop("id").startswith("ga4gh:SL.")
+
             if vrs_variation and vrs_variation not in translations:
-                assert vrs_variation in expected, f"{query}: {vrs_variation['id']}"
+                assert vrs_variation in expected, query
                 translations.append(vrs_variation)
 
         assert len(translations) == len(expected), query

--- a/tests/to_copy_number_variation/test_amplification_to_cx_var.py
+++ b/tests/to_copy_number_variation/test_amplification_to_cx_var.py
@@ -1,6 +1,7 @@
 """Module for testing Amplification to Copy Number Change"""
 import pytest
 from ga4gh.vrs import models
+from tests.conftest import cnv_assertion_checks
 
 
 @pytest.fixture(scope="module")
@@ -30,19 +31,13 @@ def test_amplification_to_cx_var(
     """Test that amplification_to_cx_var method works correctly"""
     # Using gene normalizer
     resp = test_cnv_handler.amplification_to_cx_var(gene="braf")
-    assert resp.copy_number_change.model_dump(
-        exclude_none=True
-    ) == braf_amplification.model_dump(exclude_none=True)
+    cnv_assertion_checks(resp, braf_amplification, check_vrs_id=True)
     assert resp.amplification_label == "BRAF Amplification"
-    assert resp.warnings == []
 
     # Gene with > 1 sequence location
     resp = test_cnv_handler.amplification_to_cx_var(gene="PRPF8")
-    assert resp.copy_number_change.model_dump(
-        exclude_none=True
-    ) == prpf8_amplification.model_dump(exclude_none=True)
+    cnv_assertion_checks(resp, prpf8_amplification)
     assert resp.amplification_label == "PRPF8 Amplification"
-    assert resp.warnings == []
 
     # Gene with no location. This should NOT return a variation
     resp = test_cnv_handler.amplification_to_cx_var(gene="ifnr")
@@ -56,11 +51,8 @@ def test_amplification_to_cx_var(
     resp = test_cnv_handler.amplification_to_cx_var(
         gene="KIT", sequence_id="NC_000004.11", start=55599321, end=55599321
     )
-    assert resp.copy_number_change.model_dump(
-        exclude_none=True
-    ) == kit_amplification.model_dump(exclude_none=True)
+    cnv_assertion_checks(resp, kit_amplification)
     assert resp.amplification_label == "KIT Amplification"
-    assert resp.warnings == []
 
     # Sequence_id not found in seqrepo
     resp = test_cnv_handler.amplification_to_cx_var(

--- a/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
@@ -1,5 +1,4 @@
 """Module for testing the hgvs to copy number count and copy number change endpoints"""
-import copy
 
 import pytest
 from ga4gh.vrs import models
@@ -22,7 +21,6 @@ def genomic_dup1_cx_38(genomic_dup1_seq_loc_not_normalized):
 def genomic_dup1_37_loc():
     """Create test fixture GRCh37 duplication location"""
     return {
-        "id": "ga4gh:SL.ntKfbY4eZVFNOAMuZPb4RBRhINxvOmM9",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.VNBualIltAyi2AI_uXcKU7M9XUOuA7MS",
@@ -38,7 +36,6 @@ def genomic_dup1_cn_37(genomic_dup1_37_loc):
     """Create test fixture copy number count variation (not normalized)"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.-TsNBiFhHFcWLb7pz9GCWcJunlBmb_B4",
         "location": genomic_dup1_37_loc,
         "copies": 3,
     }
@@ -50,7 +47,6 @@ def genomic_dup1_cx_37(genomic_dup1_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.inPVJ3ANsN-Xb22HakFf_BmMg73gZiFo",
         "location": genomic_dup1_37_loc,
         "copyChange": "efo:0030069",
     }
@@ -62,7 +58,6 @@ def genomic_dup2_cx_38(genomic_dup2_seq_loc_normalized):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.uchcAvP6DXLirT7zASWHcWwmGWPLc8ye",
         "location": genomic_dup2_seq_loc_normalized,
         "copyChange": "efo:0030067",
     }
@@ -73,7 +68,6 @@ def genomic_dup2_cx_38(genomic_dup2_seq_loc_normalized):
 def genomic_dup2_37_loc():
     """Create test fixture GRCh37 duplication location"""
     return {
-        "id": "ga4gh:SL.g5_YcFgvTQSCuirJLMviwlue4NTb9EJ-",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -89,7 +83,6 @@ def genomic_dup2_cn_37(genomic_dup2_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.jQdYqHKs7Y7BPQq5lBIddKd208iJrskw",
         "location": genomic_dup2_37_loc,
         "copies": 3,
     }
@@ -101,7 +94,6 @@ def genomic_dup2_cx_37(genomic_dup2_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.6Nzma3vnsYb7ZqJ0XSiqv2F8-XFDKMyP",
         "location": genomic_dup2_37_loc,
         "copyChange": "efo:0030067",
     }
@@ -113,7 +105,6 @@ def genomic_dup3_cx_38(genomic_del3_dup3_loc_not_normalized):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.3CEaG1qP1k9AU_aae_iIUx4uaTb72N1R",
         "location": genomic_del3_dup3_loc_not_normalized,
         "copyChange": "efo:0030072",
     }
@@ -124,7 +115,6 @@ def genomic_dup3_cx_38(genomic_del3_dup3_loc_not_normalized):
 def genomic_dup3_37_loc():
     """Create test fixture GRCh37 duplication location"""
     return {
-        "id": "ga4gh:SL.xDN-t4g0hLgYTKyh3_88Drln1HdishyF",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -140,7 +130,6 @@ def genomic_del3_dup3_cn_37(genomic_dup3_37_loc):
     """Create test fixture copy number variation for del/dup 3 on GRCh37"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.TFwnv4Lv7f2ZvboyqSBygWbC57QzuQ8R",
         "location": genomic_dup3_37_loc,
         "copies": 2,
     }
@@ -152,7 +141,6 @@ def genomic_dup3_cx_37(genomic_dup3_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.A9Z_PAgta0MwukOSjrntOneG9N66_FED",
         "location": genomic_dup3_37_loc,
         "copyChange": "efo:0030072",
     }
@@ -164,7 +152,6 @@ def genomic_dup4_cn_38(genomic_dup4_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.KqbQewUgZYfmottbgn1xYq58DiPVU5SZ",
         "location": genomic_dup4_loc,
         "copies": 3,
     }
@@ -176,7 +163,6 @@ def genomic_dup4_cx_38(genomic_dup4_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.X0nbb6qzkjqisoT8Ls_7-OS9KkYfTCCu",
         "location": genomic_dup4_loc,
         "copyChange": "efo:0030069",
     }
@@ -187,7 +173,6 @@ def genomic_dup4_cx_38(genomic_dup4_loc):
 def genomic_dup4_37_loc():
     """Create test fixture GRCh37 duplication location"""
     return {
-        "id": "ga4gh:SL.WVXqGHNVaD96semkKQVfTuEo4TN-yMGE",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.iy_UbUrvECxFRX5LPTH_KPojdlT7BKsf",
@@ -203,7 +188,6 @@ def genomic_dup4_cn_37(genomic_dup4_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.m19rHAtbxPm8ojn1pZm7Pq7e00WJkE75",
         "location": genomic_dup4_37_loc,
         "copies": 3,
     }
@@ -215,7 +199,6 @@ def genomic_dup4_cx_37(genomic_dup4_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.5cVAesP5EKfh3uOTXe-BWyHdsFEvW7a0",
         "location": genomic_dup4_37_loc,
         "copyChange": "efo:0030069",
     }
@@ -227,7 +210,6 @@ def genomic_dup5_cn_38(genomic_dup5_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.hTq6Z10Mg7rS_T_uoODhF24HmvRdEkLk",
         "location": genomic_dup5_loc,
         "copies": 4,
     }
@@ -239,7 +221,6 @@ def genomic_dup5_cx_38(genomic_dup5_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.bR_i_ztx0rLrEbML1B_xoqJ50W39qlKN",
         "location": genomic_dup5_loc,
         "copyChange": "efo:0030067",
     }
@@ -250,7 +231,6 @@ def genomic_dup5_cx_38(genomic_dup5_loc):
 def genomic_dup5_37_loc():
     """Create test fixture GRCh37 duplication location"""
     return {
-        "id": "ga4gh:SL.hS8rIdNliH9F4YuLlHhxLIdrHVVrCEXz",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -266,7 +246,6 @@ def genomic_dup5_cn_37(genomic_dup5_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.QdhteI3bI3qRFEZOk9pmICPsKFI6MCXd",
         "location": genomic_dup5_37_loc,
         "copies": 4,
     }
@@ -278,7 +257,6 @@ def genomic_dup5_cx_37(genomic_dup5_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.PJWAoRYtFYcewmPtM5W2eG6TSef7gAyJ",
         "location": genomic_dup5_37_loc,
         "copyChange": "efo:0030067",
     }
@@ -290,7 +268,6 @@ def genomic_dup6_cn_38(genomic_dup6_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.KSFn5KQIPuPVJ6FjWaF0vzl7eRwwHbX9",
         "location": genomic_dup6_loc,
         "copies": 2,
     }
@@ -302,7 +279,6 @@ def genomic_dup6_cx_38(genomic_dup6_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.5irbnyk3aqsHCEbs2WAgiNpChn3asZgQ",
         "location": genomic_dup6_loc,
         "copyChange": "efo:0030064",
     }
@@ -313,7 +289,6 @@ def genomic_dup6_cx_38(genomic_dup6_loc):
 def genomic_dup6_37_loc():
     """Create test fixture GRCh37 duplication location"""
     return {
-        "id": "ga4gh:SL.xoQ6AO6YVSUdlvcO5WtpXGJykEbMktY6",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -329,7 +304,6 @@ def genomic_dup6_cn_37(genomic_dup6_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.SijB_fXpFimGmPnWe2YHNcVv4NyEp9Uo",
         "location": genomic_dup6_37_loc,
         "copies": 2,
     }
@@ -341,7 +315,6 @@ def genomic_dup6_cx_37(genomic_dup6_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.IkUmxq_kjLmo2mPv4eg9fgcd3B12tT4G",
         "location": genomic_dup6_37_loc,
         "copyChange": "efo:0030064",
     }
@@ -353,7 +326,6 @@ def genomic_del1_cx_38(genomic_del1_seq_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.LWRBNtBgcETMXEKezrr7WUPjO9WoOaqL",
         "location": genomic_del1_seq_loc,
         "copyChange": "efo:0030064",
     }
@@ -364,7 +336,6 @@ def genomic_del1_cx_38(genomic_del1_seq_loc):
 def genomic_del1_37_loc():
     """Create test fixture GRCh37 deletion location"""
     return {
-        "id": "ga4gh:SL.zz9AUA6ANv3OPftr3dI-7GxGeaZKeADW",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.VNBualIltAyi2AI_uXcKU7M9XUOuA7MS",
@@ -380,7 +351,6 @@ def genomic_del1_cn_37(genomic_del1_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN._n2CTBQdDMSObUf6DPdj5t7XLPAQ-Ojt",
         "location": genomic_del1_37_loc,
         "copies": 1,
     }
@@ -392,7 +362,6 @@ def genomic_del1_cx_37(genomic_del1_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.KqiBf1gspLI7WQu-wVOFYrG1HhLyqFlV",
         "location": genomic_del1_37_loc,
         "copyChange": "efo:0030064",
     }
@@ -404,7 +373,6 @@ def genomic_del2_cx_38(genomic_del2_seq_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.ehFxhcx6VUozuQxTd4vskjpaUIptU0Qg",
         "location": genomic_del2_seq_loc,
         "copyChange": "efo:0030071",
     }
@@ -415,7 +383,6 @@ def genomic_del2_cx_38(genomic_del2_seq_loc):
 def genomic_del2_37_loc():
     """Create test fixture GRCh37 deletion location"""
     return {
-        "id": "ga4gh:SL.BwPpPS55EYrek4Gs7xdd8sNjYJvcZRi7",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.VNBualIltAyi2AI_uXcKU7M9XUOuA7MS",
@@ -431,7 +398,6 @@ def genomic_del2_cn_37(genomic_del2_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.ic8DuXVLz-cFut46rneGHbkACsEQg832",
         "location": genomic_del2_37_loc,
         "copies": 1,
     }
@@ -443,7 +409,6 @@ def genomic_del2_cx_37(genomic_del2_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.0i-lR3bpBiuYAGC4D7UErkrrgrawJahz",
         "location": genomic_del2_37_loc,
         "copyChange": "efo:0030071",
     }
@@ -455,7 +420,6 @@ def genomic_del3_cx_38(genomic_del3_dup3_loc_not_normalized):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.-9fCLzZprnBM-nl08MJUo5oqZ4ehduv7",
         "location": genomic_del3_dup3_loc_not_normalized,
         "copyChange": "efo:0030069",
     }
@@ -466,7 +430,6 @@ def genomic_del3_cx_38(genomic_del3_dup3_loc_not_normalized):
 def genomic_del3_37_loc():
     """Create test fixture GRCh37 deletion location"""
     return {
-        "id": "ga4gh:SL.xDN-t4g0hLgYTKyh3_88Drln1HdishyF",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -482,7 +445,6 @@ def genomic_del3_cx_37(genomic_del3_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.uiJMtQrX_-w3-ehTTu7o2ByqatZYhYVu",
         "location": genomic_del3_37_loc,
         "copyChange": "efo:0030069",
     }
@@ -494,7 +456,6 @@ def genomic_del4_cn_38(genomic_del4_seq_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.2k3RnvQtBIIIqSqVlTT7Uh0KeuD8LIpK",
         "location": genomic_del4_seq_loc,
         "copies": 4,
     }
@@ -506,7 +467,6 @@ def genomic_del4_cx_38(genomic_del4_seq_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.1DiUzraiKZLJb8oF8ynARS816fthsJpV",
         "location": genomic_del4_seq_loc,
         "copyChange": "efo:0030067",
     }
@@ -517,7 +477,6 @@ def genomic_del4_cx_38(genomic_del4_seq_loc):
 def genomic_del4_37_loc():
     """Create test fixture GRCh37 deletion location"""
     return {
-        "id": "ga4gh:SL.2ORImLGRcezhWXDYI9sZvLwFGPDH9WKS",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -533,7 +492,6 @@ def genomic_del4_cn_37(genomic_del4_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.Mv42RTfmPVQV4nSoytbDbK4cfsUO0wyD",
         "location": genomic_del4_37_loc,
         "copies": 4,
     }
@@ -545,7 +503,6 @@ def genomic_del4_cx_37(genomic_del4_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.CJdXMZXSEE4hCIwjGxke4EWY7lMENYPj",
         "location": genomic_del4_37_loc,
         "copyChange": "efo:0030067",
     }
@@ -557,7 +514,6 @@ def genomic_del5_cn_38(genomic_del5_seq_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.VIYxNpNj8c5ulSfr8mFkxTBCGMunoUIN",
         "location": genomic_del5_seq_loc,
         "copies": 2,
     }
@@ -569,7 +525,6 @@ def genomic_del5_cx_38(genomic_del5_seq_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.w-H5jcMK0AijJomgeu_LhN5IQ_0Z0GIi",
         "location": genomic_del5_seq_loc,
         "copyChange": "efo:0030064",
     }
@@ -580,7 +535,6 @@ def genomic_del5_cx_38(genomic_del5_seq_loc):
 def genomic_del5_37_loc():
     """Create test fixture GRCh37 deletion location"""
     return {
-        "id": "ga4gh:SL.xYPrcJoKhU-xWyeBB4-DzYmFYOEynMBy",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -596,7 +550,6 @@ def genomic_del5_cn_37(genomic_del5_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.9qwSqDhzXCHPSWycZ-qePwwEXrCpQ02A",
         "location": genomic_del5_37_loc,
         "copies": 2,
     }
@@ -608,7 +561,6 @@ def genomic_del5_cx_37(genomic_del5_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.ICA0LcW-0gaOgJziPZJcGdXQ_MR3OiDu",
         "location": genomic_del5_37_loc,
         "copyChange": "efo:0030064",
     }
@@ -620,7 +572,6 @@ def genomic_del6_cn_38(genomic_del6_seq_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.CZEc44pX7Dh9yJARvvz6EW9oQvgkbwYf",
         "location": genomic_del6_seq_loc,
         "copies": 1,
     }
@@ -632,7 +583,6 @@ def genomic_del6_cx_38(genomic_del6_seq_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.02f8o7Gz9y11bMOWl7Vacc3V5J5M82bH",
         "location": genomic_del6_seq_loc,
         "copyChange": "efo:0030071",
     }
@@ -643,7 +593,6 @@ def genomic_del6_cx_38(genomic_del6_seq_loc):
 def genomic_del6_37_loc():
     """Create test fixture GRCh37 deletion location"""
     return {
-        "id": "ga4gh:SL.nENEk628TbRKyB9H9n12ssAQZnpwJDUo",
         "sequenceReference": {
             "type": "SequenceReference",
             "refgetAccession": "SQ.KqaUhJMW3CDjhoVtBetdEKT1n6hM-7Ek",
@@ -659,7 +608,6 @@ def genomic_del6_cn_37(genomic_del6_37_loc):
     """Create test fixture copy number count variation"""
     params = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.dPP5zGqiwSPNnuj49POIaul6_3msLwgF",
         "location": genomic_del6_37_loc,
         "copies": 1,
     }
@@ -671,7 +619,6 @@ def genomic_del6_cx_37(genomic_del6_37_loc):
     """Create test fixture copy number change variation"""
     params = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.2YOJ93--D5aER5HsmnM4JP8GLWCcKKN-",
         "location": genomic_del6_37_loc,
         "copyChange": "efo:0030071",
     }
@@ -689,7 +636,7 @@ async def test_genomic_dup1_copy_number_count(
         baseline_copies=2,
         do_liftover=False,
     )
-    cnv_assertion_checks(resp, genomic_dup1_38_cn)
+    cnv_assertion_checks(resp, genomic_dup1_38_cn, check_vrs_id=True)
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_count(
@@ -702,14 +649,6 @@ async def test_genomic_dup1_copy_number_count(
     )
     cnv_assertion_checks(resp, genomic_dup1_38_cn)
 
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=1, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_dup1_38_cn)
-    expected.copies = 2
-    expected.id = "ga4gh:CN.BvXjVTvckz3zAp8yATcQjLp-1sWyEO9d"
-    cnv_assertion_checks(resp, expected)
-
 
 @pytest.mark.asyncio()
 async def test_genomic_dup1_copy_number_change(
@@ -720,7 +659,7 @@ async def test_genomic_dup1_copy_number_change(
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
         q, copy_change="efo:0030069", do_liftover=False
     )
-    cnv_assertion_checks(resp, genomic_dup1_cx_38)
+    cnv_assertion_checks(resp, genomic_dup1_cx_38, check_vrs_id=True)
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
@@ -755,14 +694,6 @@ async def test_genomic_dup2_copy_number_count(
         q, baseline_copies=2, do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup2_38_cn)
-
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=1, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_dup2_38_cn)
-    expected.copies = 2
-    expected.id = "ga4gh:CN.40RjBTowl-97BT5vsPUgqdLJKNvL583c"
-    cnv_assertion_checks(resp, expected)
 
 
 @pytest.mark.asyncio()
@@ -810,14 +741,6 @@ async def test_genomic_dup3_copy_number_count(
     )
     cnv_assertion_checks(resp, genomic_del3_dup3_cn_38)
 
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=2, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del3_dup3_cn_38)
-    expected.copies = 3
-    expected.id = "ga4gh:CN.k_3m5Hu3_J5Mb8Rx8zH0plZ12U0XD1Du"
-    cnv_assertion_checks(resp, expected)
-
 
 @pytest.mark.asyncio()
 async def test_genomic_dup3_copy_number_change(
@@ -863,14 +786,6 @@ async def test_genomic_dup4_copy_number_count(
         q, baseline_copies=2, do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup4_cn_38)
-
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=1, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_dup4_cn_38)
-    expected.copies = 2
-    expected.id = "ga4gh:CN.214AwcxGQiu1rY8UYQpud23sQI5DJbm1"
-    cnv_assertion_checks(resp, expected)
 
 
 @pytest.mark.asyncio()
@@ -918,14 +833,6 @@ async def test_genomic_dup5_copy_number_count(
     )
     cnv_assertion_checks(resp, genomic_dup5_cn_38)
 
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=4, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_dup5_cn_38)
-    expected.copies = 5
-    expected.id = "ga4gh:CN.XvDElgE55k4blDLkzlDhwh5xcGyZrucn"
-    cnv_assertion_checks(resp, expected)
-
 
 @pytest.mark.asyncio()
 async def test_genomic_dup5_copy_number_change(
@@ -971,14 +878,6 @@ async def test_genomic_dup6_copy_number_count(
         q, baseline_copies=1, do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup6_cn_38)
-
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=2, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_dup6_cn_38)
-    expected.copies = 3
-    expected.id = "ga4gh:CN.px3rDGLGlOmJLGKBoojl1UrFKu6Rhb1P"
-    cnv_assertion_checks(resp, expected)
 
 
 @pytest.mark.asyncio()
@@ -1026,14 +925,6 @@ async def test_genomic_del1_copy_number_count(
     )
     cnv_assertion_checks(resp, genomic_del1_38_cn)
 
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=3, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del1_38_cn)
-    expected.copies = 2
-    expected.id = "ga4gh:CN.S0viz7yEPYtrHIBxBLlCKnIc9x8FspQp"
-    cnv_assertion_checks(resp, expected)
-
 
 @pytest.mark.asyncio()
 async def test_genomic_del1_copy_number_change(
@@ -1079,14 +970,6 @@ async def test_genomic_del2_copy_number_count(
         q, baseline_copies=2, do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del2_38_cn)
-
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=4, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del2_38_cn)
-    expected.copies = 3
-    expected.id = "ga4gh:CN.d8thjAuvDC3acnDwFnz2Mg6PEMipVNJk"
-    cnv_assertion_checks(resp, expected)
 
 
 @pytest.mark.asyncio()
@@ -1134,14 +1017,6 @@ async def test_genomic_del3_copy_number_count(
     )
     cnv_assertion_checks(resp, genomic_del3_dup3_cn_38)
 
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=2, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del3_dup3_cn_38)
-    expected.copies = 1
-    expected.id = "ga4gh:CN.vqcaYwbK8oewMEtKbP2pn5npQtkOAGdo"
-    cnv_assertion_checks(resp, expected)
-
 
 @pytest.mark.asyncio()
 async def test_genomic_del3_copy_number_change(
@@ -1187,14 +1062,6 @@ async def test_genomic_del4_copy_number_count(
         q, baseline_copies=5, do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del4_cn_38)
-
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=3, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del4_cn_38)
-    expected.copies = 2
-    expected.id = "ga4gh:CN.9qA8nLBcResblQhR0xfz16vPHP-tYXIA"
-    cnv_assertion_checks(resp, expected)
 
 
 @pytest.mark.asyncio()
@@ -1242,14 +1109,6 @@ async def test_genomic_del5_copy_number_count(
     )
     cnv_assertion_checks(resp, genomic_del5_cn_38)
 
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=2, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del5_cn_38)
-    expected.copies = 1
-    expected.id = "ga4gh:CN.7tln8gxFt8FfLrJH7XlcX7PVSQCQqnNZ"
-    cnv_assertion_checks(resp, expected)
-
 
 @pytest.mark.asyncio()
 async def test_genomic_del5_copy_number_change(
@@ -1295,14 +1154,6 @@ async def test_genomic_del6_copy_number_count(
         q, baseline_copies=2, do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del6_cn_38)
-
-    resp = await test_cnv_handler.hgvs_to_copy_number_count(
-        q, baseline_copies=3, do_liftover=True
-    )
-    expected = copy.deepcopy(genomic_del6_cn_38)
-    expected.copies = 2
-    expected.id = "ga4gh:CN.ydRovIJjiYNRUGv0w3iJ-pgK08MuYqGR"
-    cnv_assertion_checks(resp, expected)
 
 
 @pytest.mark.asyncio()

--- a/tests/to_copy_number_variation/test_parsed_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_parsed_to_copy_number.py
@@ -46,10 +46,8 @@ def cn_gain2():
     """
     variation = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.-SqT6JTz0WpKfGQjdHnuJnyK8YMcAmez",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.2f5wWnJ52UShqq0wRTahKWH-YFCFTixG",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.AsXvWL1-2i5U_buw6_niVIxD6zTbAuS6",
@@ -69,10 +67,8 @@ def cn_gain2_37():
     """
     variation = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.gtS4om__GNKDFZxdtno7Cwiv_8Tv0_As",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.knW3_K9Kj2bvgGvnW3uorAEhZ9lnBD4F",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.zIMZb3Ft7RdWa5XYq0PxIlezLY2ccCgt",
@@ -92,10 +88,8 @@ def cn_loss1():
     """
     variation = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.ckk73c3GG4x-P0uL5Iv1tzBPxYea1V03",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.S_YZii49zAuWk8hA71OD5Ud1mtQRpw5T",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.v7noePfnNpK8ghYXEqZ9NukMXW7YeNsm",
@@ -115,10 +109,8 @@ def cn_loss2():
     """
     variation = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.6vQIGMEa94FNmLBwQLHRTHaf_yrjMnBz",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.xeLChE7XHqLtLjrVEBnHpxvtdWjRA0Aw",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -138,10 +130,8 @@ def cn_definite_number():
     """
     variation = {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.8xU8MDlKeD7kyhiVJmSwvi3iV78ReIc5",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.NqQ42igO9R3BBbA7q7jQ_81rfZOjpzGg",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
@@ -182,10 +172,8 @@ def cx_definite_ranges():
     """
     variation = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.gn7z-74PrlvMWAVK7jsP9oYnp0pCezee",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.jOyDc0XwpyvY-SqxowgWxb7N5ODEYc4I",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -205,10 +193,8 @@ def cx_indefinite_ranges():
     """
     variation = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.2lbeFEsxiN9sdMRtqiaYaM0HPy2UJWEC",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.-XBGqDkrHG7D19jCYuvNfEeJoBSBEHFA",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -228,10 +214,8 @@ def cx_number_indefinite():
     """
     variation = {
         "type": "CopyNumberChange",
-        "id": "ga4gh:CX.38jEUd5AhCbQk9hB36hS6mEqRKlY7ugj",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.XuivAIjbPg8CLUUz7TZXO6mJWfAfU6HJ",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5",
@@ -244,25 +228,29 @@ def cx_number_indefinite():
     return models.CopyNumberChange(**variation)
 
 
+GRCH37_CHR7_VRS_ID = "ga4gh:SQ.IW78mgV5Cqf6M24hy52hPjyyo5tCCd86"
+GRCH38_CHR7_VRS_ID = "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+
+
 def test_get_parsed_ac(test_cnv_handler):
     """Test that _get_parsed_ac works correctly"""
     for assembly in [ClinVarAssembly.GRCH37, ClinVarAssembly.HG19]:
         resp = test_cnv_handler._get_parsed_ac(assembly, "chr7", use_grch38=False)
         assert resp.lifted_over is False
-        assert resp.accession == "ga4gh:SQ.IW78mgV5Cqf6M24hy52hPjyyo5tCCd86"
+        assert resp.accession == GRCH37_CHR7_VRS_ID
 
         resp = test_cnv_handler._get_parsed_ac(assembly, "chr7", use_grch38=True)
         assert resp.lifted_over is True
-        assert resp.accession == "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+        assert resp.accession == GRCH38_CHR7_VRS_ID
 
     for assembly in [ClinVarAssembly.GRCH38, ClinVarAssembly.HG38]:
         resp = test_cnv_handler._get_parsed_ac(assembly, "chr7", use_grch38=False)
         assert resp.lifted_over is False
-        assert resp.accession == "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+        assert resp.accession == GRCH38_CHR7_VRS_ID
 
         resp = test_cnv_handler._get_parsed_ac(assembly, "chr7", use_grch38=True)
         assert resp.lifted_over is False
-        assert resp.accession == "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+        assert resp.accession == GRCH38_CHR7_VRS_ID
 
     with pytest.raises(ToCopyNumberError) as e:
         test_cnv_handler._get_parsed_ac(
@@ -278,18 +266,18 @@ def test_get_parsed_ac(test_cnv_handler):
 def test_get_parsed_ac_chr(test_cnv_handler):
     """Test that _get_parsed_ac_chr works correctly"""
     resp = test_cnv_handler._get_parsed_ac_chr("NC_000007.13", False)
-    assert resp.accession == "ga4gh:SQ.IW78mgV5Cqf6M24hy52hPjyyo5tCCd86"
+    assert resp.accession == GRCH37_CHR7_VRS_ID
     assert resp.chromosome == "chr7"
     assert resp.lifted_over is False
 
     resp = test_cnv_handler._get_parsed_ac_chr("NC_000007.13", True)
-    assert resp.accession == "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+    assert resp.accession == GRCH38_CHR7_VRS_ID
     assert resp.chromosome == "chr7"
     assert resp.lifted_over is True
 
     for do_liftover in [True, False]:
         resp = test_cnv_handler._get_parsed_ac_chr("NC_000007.14", do_liftover)
-        assert resp.accession == "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+        assert resp.accession == GRCH38_CHR7_VRS_ID
         assert resp.chromosome == "chr7"
         assert resp.lifted_over is False
 
@@ -419,7 +407,7 @@ def test_parsed_copy_number_gain(test_cnv_handler, cn_gain1, cn_gain2, cn_gain2_
         end_pos_comparator=Comparator.GT_OR_EQUAL,
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
-    cnv_assertion_checks(resp, cn_gain1)
+    cnv_assertion_checks(resp, cn_gain1, check_vrs_id=True)
 
     rb = ParsedToCnVarQuery(
         start0=143134063,
@@ -717,7 +705,6 @@ def test_to_parsed_cn_var(test_cnv_handler, cn_definite_number):
     resp = test_cnv_handler.parsed_to_copy_number(rb)
     expected = deepcopy(cn_definite_number)
     expected.copies = models.Range([3, 5])
-    expected.id = "ga4gh:CN.Z-nHquCOaZ9-7qlEiHJjTCNTun8rphs5"
     cnv_assertion_checks(resp, expected)
 
     # copies is indefinite range <=
@@ -735,7 +722,6 @@ def test_to_parsed_cn_var(test_cnv_handler, cn_definite_number):
     resp = test_cnv_handler.parsed_to_copy_number(rb)
     expected = deepcopy(cn_definite_number)
     expected.copies = models.Range([None, 3])
-    expected.id = "ga4gh:CN.ATCEmOahCspjTUZwYcg3hZVEhonOxqZ0"
     cnv_assertion_checks(resp, expected)
 
     # copies is indefinite range >=
@@ -753,7 +739,6 @@ def test_to_parsed_cn_var(test_cnv_handler, cn_definite_number):
     resp = test_cnv_handler.parsed_to_copy_number(rb)
     expected = deepcopy(cn_definite_number)
     expected.copies = [3, None]
-    expected.id = "ga4gh:CN.sXOp5QcykicrYTyRgzJvk4O9ha6ignDd"
     cnv_assertion_checks(resp, expected)
 
     # start_pos and end_pos indefinite range
@@ -769,12 +754,13 @@ def test_to_parsed_cn_var(test_cnv_handler, cn_definite_number):
         end_pos_comparator=Comparator.LT_OR_EQUAL,
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
-    assert resp.copy_number_count.model_dump(exclude_none=True) == {
+    cnc = resp.copy_number_count.model_dump(exclude_none=True)
+    assert cnc.pop("id").startswith("ga4gh:CN.")
+    assert cnc["location"].pop("id").startswith("ga4gh:SL.")
+    assert cnc == {
         "type": "CopyNumberCount",
-        "id": "ga4gh:CN.Hw32hEhUrWYl1j3Nty4cmrZlbveSw8oF",
         "location": {
             "type": "SequenceLocation",
-            "id": "ga4gh:SL.nXrqjadKZikhhdHvDmgVovb0HiKoXRq7",
             "sequenceReference": {
                 "type": "SequenceReference",
                 "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
@@ -805,7 +791,7 @@ def test_parsed_to_cx_var(
         end_pos_type=ParsedPosType.NUMBER,
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
-    cnv_assertion_checks(resp, cx_numbers)
+    cnv_assertion_checks(resp, cx_numbers, check_vrs_id=True)
 
     # start and end use definite ranges
     rb = ParsedToCxVarQuery(


### PR DESCRIPTION
close #320

* We do not need to be checking VRS IDs on every single test. This reduces to making this check in one place where ga4gh_identify function is called