### PR TITLE
feat!: update models to vrs 2.0.0 community review ballot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "pydantic ==2.*",
     "ga4gh.vrs[extras] ==2.0.0a13",
-    "gene-normalizer ~=5.0.0",
+    "gene-normalizer ~=0.5.0",
     "boto3",
     "cool-seq-tool ~=0.6.0",
     "bioutils"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "pydantic ==2.*",
     "ga4gh.vrs[extras] ==2.0.0a13",
-    "gene-normalizer ~=0.5.0",
+    "gene-normalizer ~=0.6.0",
     "boto3",
     "cool-seq-tool ~=0.6.0",
     "bioutils"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "pydantic ==2.*",
-    "ga4gh.vrs[extras] ~= 2.0.0a10",
-    "gene-normalizer ~=0.4.0",
+    "ga4gh.vrs[extras] ==2.0.0a13",
+    "gene-normalizer ~=5.0.0",
     "boto3",
     "cool-seq-tool ~=0.6.0",
     "bioutils"

--- a/src/variation/gnomad_vcf_to_protein_variation.py
+++ b/src/variation/gnomad_vcf_to_protein_variation.py
@@ -5,7 +5,8 @@ import datetime
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.mappers import ManeTranscript
 from cool_seq_tool.schemas import Strand
-from ga4gh.core import domain_models, ga4gh_identify
+from ga4gh.core import ga4gh_identify
+from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models, normalize
 from gene.query import QueryHandler as GeneQueryHandler
 from gene.schemas import MatchType as GeneMatchType
@@ -413,14 +414,14 @@ class GnomadVcfToProteinVariation:
             self.seqrepo_access, p_ac, variation.location.start, variation.location.end
         )
         if loc_seq:
-            variation.location.sequence = models.SequenceString(root=loc_seq)
+            variation.location.sequence = models.sequenceString(root=loc_seq)
 
         # Add VRS digests for VRS Allele and VRS Sequence Location
         variation.id = ga4gh_identify(variation)
         variation.location.id = ga4gh_identify(variation.location)
         return variation
 
-    def _get_gene_context(self, gene: str) -> domain_models.Gene | None:
+    def _get_gene_context(self, gene: str) -> MappableConcept | None:
         """Get additional gene information from gene-normalizer
 
         :param gene: Gene symbol

--- a/src/variation/hgvs_dup_del_mode.py
+++ b/src/variation/hgvs_dup_del_mode.py
@@ -2,7 +2,8 @@
 
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.schemas import ResidueMode
-from ga4gh.core import entity_models, ga4gh_identify
+from ga4gh.core import ga4gh_identify
+from ga4gh.core.models import Extension, MappableConcept
 from ga4gh.vrs import models, normalize
 
 from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
@@ -49,7 +50,7 @@ class HGVSDupDelMode:
         baseline_copies: int | None = None,
         copy_change: models.CopyChange | None = None,
         alt: str | None = None,
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict | None:
         """Use default characteristics to return a variation.
         If baseline_copies not provided and endpoints are ambiguous - copy_number_change
@@ -92,7 +93,7 @@ class HGVSDupDelMode:
         alt_type: AltType,
         location: dict,
         baseline_copies: int,
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict:
         """Return a VRS Copy Number Variation.
 
@@ -119,7 +120,7 @@ class HGVSDupDelMode:
         alt_type: AltType,
         location: dict,
         copy_change: models.CopyChange | None = None,
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict:
         """Return copy number change variation
 
@@ -142,7 +143,9 @@ class HGVSDupDelMode:
         seq_loc = models.SequenceLocation(**location)
         seq_loc.id = ga4gh_identify(seq_loc)
         cx = models.CopyNumberChange(
-            location=seq_loc, copyChange=copy_change, extensions=extensions
+            location=seq_loc,
+            copyChange=MappableConcept(primaryCode=copy_change),
+            extensions=extensions,
         )
         cx.id = ga4gh_identify(cx)
         return cx.model_dump(exclude_none=True)
@@ -153,7 +156,7 @@ class HGVSDupDelMode:
         alt_type: AltType,
         vrs_seq_loc_ac: str,
         alt: str,
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict | None:
         """Return a VRS Allele with a normalized LiteralSequenceExpression or
         ReferenceLengthExpression.
@@ -208,7 +211,7 @@ class HGVSDupDelMode:
         baseline_copies: int | None = None,
         copy_change: models.CopyChange | None = None,
         alt: str | None = None,
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict:
         """Interpret variation using HGVSDupDelMode
 

--- a/src/variation/hgvs_dup_del_mode.py
+++ b/src/variation/hgvs_dup_del_mode.py
@@ -3,11 +3,14 @@
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.schemas import ResidueMode
 from ga4gh.core import ga4gh_identify
-from ga4gh.core.models import Extension, MappableConcept
+from ga4gh.core.models import (
+    Extension,
+)
 from ga4gh.vrs import models, normalize
 
 from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 from variation.schemas.token_response_schema import AMBIGUOUS_REGIONS, AltType
+from variation.utils import get_copy_change
 
 # Define deletion alt types
 DELS = {AltType.DELETION_AMBIGUOUS, AltType.DELETION}
@@ -144,7 +147,7 @@ class HGVSDupDelMode:
         seq_loc.id = ga4gh_identify(seq_loc)
         cx = models.CopyNumberChange(
             location=seq_loc,
-            copyChange=MappableConcept(primaryCode=copy_change),
+            copyChange=get_copy_change(copy_change),
             extensions=extensions,
         )
         cx.id = ga4gh_identify(cx)

--- a/src/variation/hgvs_dup_del_mode.py
+++ b/src/variation/hgvs_dup_del_mode.py
@@ -10,7 +10,7 @@ from ga4gh.vrs import models, normalize
 
 from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 from variation.schemas.token_response_schema import AMBIGUOUS_REGIONS, AltType
-from variation.utils import get_copy_change
+from variation.utils import get_copy_change_concept
 
 # Define deletion alt types
 DELS = {AltType.DELETION_AMBIGUOUS, AltType.DELETION}
@@ -147,7 +147,7 @@ class HGVSDupDelMode:
         seq_loc.id = ga4gh_identify(seq_loc)
         cx = models.CopyNumberChange(
             location=seq_loc,
-            copyChange=get_copy_change(copy_change),
+            copyChange=get_copy_change_concept(copy_change),
             extensions=extensions,
         )
         cx.id = ga4gh_identify(cx)

--- a/src/variation/schemas/copy_number_schema.py
+++ b/src/variation/schemas/copy_number_schema.py
@@ -324,8 +324,8 @@ class ParsedToCxVarService(ServiceResponse):
             "example": {
                 "copy_number_change": {
                     "type": "CopyNumberChange",
-                    "id": "ga4gh:CX.5kaJC-7Jj851bfJ6EipsHV413feg1T4T",
-                    "digest": "5kaJC-7Jj851bfJ6EipsHV413feg1T4T",
+                    "id": "ga4gh:CX.XIsVHbhEUbXraIgpgV4ToCa-6oZWMRUD",
+                    "digest": "XIsVHbhEUbXraIgpgV4ToCa-6oZWMRUD",
                     "location": {
                         "type": "SequenceLocation",
                         "id": "ga4gh:SL.Iz_azSFTEulx7tCluLgGhE1n0hTLUocb",
@@ -337,7 +337,7 @@ class ParsedToCxVarService(ServiceResponse):
                         "start": 10000,
                         "end": 1223133,
                     },
-                    "copyChange": "efo:0030069",
+                    "copyChange": {"primaryCode": "EFO:0030069"},
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",
@@ -379,8 +379,8 @@ class AmplificationToCxVarService(ServiceResponse):
                 },
                 "amplification_label": "BRAF Amplification",
                 "copy_number_change": {
-                    "id": "ga4gh:CX._UsXDMCLtPwsVKiNByhbwfS569K1wLWW",
-                    "digest": "_UsXDMCLtPwsVKiNByhbwfS569K1wLWW",
+                    "id": "ga4gh:CX.uPQaLz6KSwXWdsjNUZ5kRn3znBZF5YwV",
+                    "digest": "uPQaLz6KSwXWdsjNUZ5kRn3znBZF5YwV",
                     "type": "CopyNumberChange",
                     "location": {
                         "id": "ga4gh:SL.0nPwKHYNnTmJ06G-gSmz8BEhB_NTp-0B",
@@ -393,7 +393,7 @@ class AmplificationToCxVarService(ServiceResponse):
                         "start": 140713327,
                         "end": 140924929,
                     },
-                    "copyChange": "efo:0030072",
+                    "copyChange": {"primaryCode": "EFO:0030072"},
                 },
                 "service_meta_": {
                     "version": __version__,

--- a/src/variation/schemas/copy_number_schema.py
+++ b/src/variation/schemas/copy_number_schema.py
@@ -337,7 +337,18 @@ class ParsedToCxVarService(ServiceResponse):
                         "start": 10000,
                         "end": 1223133,
                     },
-                    "copyChange": {"primaryCode": "EFO:0030069"},
+                    "copyChange": {
+                        "primaryCode": "EFO:0030069",
+                        "mappings": [
+                            {
+                                "coding": {
+                                    "system": "https://www.ebi.ac.uk/efo/",
+                                    "code": "EFO:0030069",
+                                },
+                                "relation": "exactMatch",
+                            }
+                        ],
+                    },
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",
@@ -393,7 +404,18 @@ class AmplificationToCxVarService(ServiceResponse):
                         "start": 140713327,
                         "end": 140924929,
                     },
-                    "copyChange": {"primaryCode": "EFO:0030072"},
+                    "copyChange": {
+                        "primaryCode": "EFO:0030072",
+                        "mappings": [
+                            {
+                                "coding": {
+                                    "system": "https://www.ebi.ac.uk/efo/",
+                                    "code": "EFO:0030072",
+                                },
+                                "relation": "exactMatch",
+                            }
+                        ],
+                    },
                 },
                 "service_meta_": {
                     "version": __version__,

--- a/src/variation/schemas/gnomad_vcf_to_protein_schema.py
+++ b/src/variation/schemas/gnomad_vcf_to_protein_schema.py
@@ -1,6 +1,6 @@
 """Module for gnomad vcf to protein response schema"""
 
-from ga4gh.core import domain_models
+from ga4gh.core.models import MappableConcept
 
 from variation.schemas.normalize_response_schema import NormalizeService
 
@@ -8,4 +8,4 @@ from variation.schemas.normalize_response_schema import NormalizeService
 class GnomadVcfToProteinService(NormalizeService):
     """Define response for gnomad vcf to protein service"""
 
-    gene_context: domain_models.Gene | None = None
+    gene_context: MappableConcept | None = None

--- a/src/variation/schemas/hgvs_to_copy_number_schema.py
+++ b/src/variation/schemas/hgvs_to_copy_number_schema.py
@@ -70,7 +70,18 @@ class HgvsToCopyNumberChangeService(ServiceResponse):
                         "start": 49531261,
                         "end": 49531262,
                     },
-                    "copyChange": {"primaryCode": "EFO:0030069"},
+                    "copyChange": {
+                        "primaryCode": "EFO:0030069",
+                        "mappings": [
+                            {
+                                "coding": {
+                                    "system": "https://www.ebi.ac.uk/efo/",
+                                    "code": "EFO:0030069",
+                                },
+                                "relation": "exactMatch",
+                            }
+                        ],
+                    },
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",

--- a/src/variation/schemas/hgvs_to_copy_number_schema.py
+++ b/src/variation/schemas/hgvs_to_copy_number_schema.py
@@ -56,8 +56,8 @@ class HgvsToCopyNumberChangeService(ServiceResponse):
             "example": {
                 "hgvs_expr": "NC_000003.12:g.49531262dup",
                 "copy_number_change": {
-                    "id": "ga4gh:CX.Zzws_y4cnoooQ7WXjg2B3nKIyFWXzOg3",
-                    "digest": "Zzws_y4cnoooQ7WXjg2B3nKIyFWXzOg3",
+                    "id": "ga4gh:CX.30bDl5yhHzjc4M5uGS_8IeYMzHQksQGh",
+                    "digest": "30bDl5yhHzjc4M5uGS_8IeYMzHQksQGh",
                     "type": "CopyNumberChange",
                     "location": {
                         "id": "ga4gh:SL.2vbgFGHGB0QGODwgZNi05fWbROkkjf04",
@@ -70,7 +70,7 @@ class HgvsToCopyNumberChangeService(ServiceResponse):
                         "start": 49531261,
                         "end": 49531262,
                     },
-                    "copyChange": "efo:0030069",
+                    "copyChange": {"primaryCode": "EFO:0030069"},
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",

--- a/src/variation/schemas/token_response_schema.py
+++ b/src/variation/schemas/token_response_schema.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Literal
 
 from cool_seq_tool.schemas import AnnotationLayer
-from ga4gh.core import domain_models
+from ga4gh.core.models import MappableConcept
 from pydantic import BaseModel, StrictInt, StrictStr
 
 from variation.schemas.app_schemas import AmbiguousRegexType
@@ -255,4 +255,4 @@ class GeneToken(Token):
 
     matched_value: StrictStr
     token_type: Literal[TokenType.GENE] = TokenType.GENE
-    gene: domain_models.Gene | None = None
+    gene: MappableConcept | None = None

--- a/src/variation/to_copy_number_variation.py
+++ b/src/variation/to_copy_number_variation.py
@@ -9,7 +9,6 @@ from cool_seq_tool.mappers import LiftOver
 from cool_seq_tool.schemas import Assembly
 from cool_seq_tool.sources import UtaDatabase
 from ga4gh.core import ga4gh_identify
-from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models
 from gene.query import QueryHandler as GeneQueryHandler
 from gene.schemas import MatchType as GeneMatchType
@@ -43,7 +42,11 @@ from variation.schemas.validation_response_schema import ValidationResult
 from variation.to_vrs import ToVRS
 from variation.tokenize import Tokenize
 from variation.translate import Translate
-from variation.utils import get_priority_sequence_location, get_vrs_loc_seq
+from variation.utils import (
+    get_copy_change,
+    get_priority_sequence_location,
+    get_vrs_loc_seq,
+)
 from variation.validate import Validate
 
 VALID_CLASSIFICATION_TYPES = [
@@ -605,7 +608,7 @@ class ToCopyNumberVariation(ToVRS):
             if is_cx:
                 variation = models.CopyNumberChange(
                     location=seq_loc,
-                    copyChange=MappableConcept(primaryCode=request_body.copy_change),
+                    copyChange=get_copy_change(request_body.copy_change),
                 )
                 variation.id = ga4gh_identify(variation)
             else:
@@ -717,9 +720,7 @@ class ToCopyNumberVariation(ToVRS):
                     vrs_location.id = ga4gh_identify(vrs_location)
                     vrs_cx = models.CopyNumberChange(
                         location=vrs_location,
-                        copyChange=MappableConcept(
-                            primaryCode=models.CopyChange.EFO_0030072.value
-                        ),
+                        copyChange=get_copy_change(models.CopyChange.EFO_0030072),
                     )
                     vrs_cx.id = ga4gh_identify(vrs_cx)
                     variation = models.CopyNumberChange(

--- a/src/variation/to_copy_number_variation.py
+++ b/src/variation/to_copy_number_variation.py
@@ -43,7 +43,7 @@ from variation.to_vrs import ToVRS
 from variation.tokenize import Tokenize
 from variation.translate import Translate
 from variation.utils import (
-    get_copy_change,
+    get_copy_change_concept,
     get_priority_sequence_location,
     get_vrs_loc_seq,
 )
@@ -608,7 +608,7 @@ class ToCopyNumberVariation(ToVRS):
             if is_cx:
                 variation = models.CopyNumberChange(
                     location=seq_loc,
-                    copyChange=get_copy_change(request_body.copy_change),
+                    copyChange=get_copy_change_concept(request_body.copy_change),
                 )
                 variation.id = ga4gh_identify(variation)
             else:
@@ -720,7 +720,9 @@ class ToCopyNumberVariation(ToVRS):
                     vrs_location.id = ga4gh_identify(vrs_location)
                     vrs_cx = models.CopyNumberChange(
                         location=vrs_location,
-                        copyChange=get_copy_change(models.CopyChange.EFO_0030072),
+                        copyChange=get_copy_change_concept(
+                            models.CopyChange.EFO_0030072
+                        ),
                     )
                     vrs_cx.id = ga4gh_identify(vrs_cx)
                     variation = models.CopyNumberChange(

--- a/src/variation/to_copy_number_variation.py
+++ b/src/variation/to_copy_number_variation.py
@@ -9,6 +9,7 @@ from cool_seq_tool.mappers import LiftOver
 from cool_seq_tool.schemas import Assembly
 from cool_seq_tool.sources import UtaDatabase
 from ga4gh.core import ga4gh_identify
+from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models
 from gene.query import QueryHandler as GeneQueryHandler
 from gene.schemas import MatchType as GeneMatchType
@@ -603,7 +604,8 @@ class ToCopyNumberVariation(ToVRS):
         else:
             if is_cx:
                 variation = models.CopyNumberChange(
-                    location=seq_loc, copyChange=request_body.copy_change
+                    location=seq_loc,
+                    copyChange=MappableConcept(primaryCode=request_body.copy_change),
                 )
                 variation.id = ga4gh_identify(variation)
             else:
@@ -715,7 +717,9 @@ class ToCopyNumberVariation(ToVRS):
                     vrs_location.id = ga4gh_identify(vrs_location)
                     vrs_cx = models.CopyNumberChange(
                         location=vrs_location,
-                        copyChange=models.CopyChange.EFO_0030072.value,
+                        copyChange=MappableConcept(
+                            primaryCode=models.CopyChange.EFO_0030072.value
+                        ),
                     )
                     vrs_cx.id = ga4gh_identify(vrs_cx)
                     variation = models.CopyNumberChange(

--- a/src/variation/translators/amplification.py
+++ b/src/variation/translators/amplification.py
@@ -9,7 +9,7 @@ from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 from variation.schemas.translation_response_schema import TranslationResult
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.translators.translator import Translator
-from variation.utils import get_copy_change, get_priority_sequence_location
+from variation.utils import get_copy_change_concept, get_priority_sequence_location
 
 
 class Amplification(Translator):
@@ -52,7 +52,7 @@ class Amplification(Translator):
         if priority_seq_loc:
             vrs_cx = models.CopyNumberChange(
                 location=models.SequenceLocation(**priority_seq_loc),
-                copyChange=get_copy_change(models.CopyChange.EFO_0030072),
+                copyChange=get_copy_change_concept(models.CopyChange.EFO_0030072),
             )
             vrs_cx.id = ga4gh_identify(vrs_cx)
             vrs_cx = vrs_cx.model_dump(exclude_none=True)

--- a/src/variation/translators/amplification.py
+++ b/src/variation/translators/amplification.py
@@ -1,7 +1,6 @@
 """Module for Amplification Translation."""
 
 from ga4gh.core import ga4gh_identify
-from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models
 
 from variation.schemas.app_schemas import Endpoint
@@ -10,7 +9,7 @@ from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 from variation.schemas.translation_response_schema import TranslationResult
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.translators.translator import Translator
-from variation.utils import get_priority_sequence_location
+from variation.utils import get_copy_change, get_priority_sequence_location
 
 
 class Amplification(Translator):
@@ -53,7 +52,7 @@ class Amplification(Translator):
         if priority_seq_loc:
             vrs_cx = models.CopyNumberChange(
                 location=models.SequenceLocation(**priority_seq_loc),
-                copyChange=MappableConcept(primaryCode=models.CopyChange.EFO_0030072),
+                copyChange=get_copy_change(models.CopyChange.EFO_0030072),
             )
             vrs_cx.id = ga4gh_identify(vrs_cx)
             vrs_cx = vrs_cx.model_dump(exclude_none=True)

--- a/src/variation/translators/amplification.py
+++ b/src/variation/translators/amplification.py
@@ -1,6 +1,7 @@
 """Module for Amplification Translation."""
 
 from ga4gh.core import ga4gh_identify
+from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models
 
 from variation.schemas.app_schemas import Endpoint
@@ -52,7 +53,7 @@ class Amplification(Translator):
         if priority_seq_loc:
             vrs_cx = models.CopyNumberChange(
                 location=models.SequenceLocation(**priority_seq_loc),
-                copyChange=models.CopyChange.EFO_0030072,
+                copyChange=MappableConcept(primaryCode=models.CopyChange.EFO_0030072),
             )
             vrs_cx.id = ga4gh_identify(vrs_cx)
             vrs_cx = vrs_cx.model_dump(exclude_none=True)

--- a/src/variation/translators/translator.py
+++ b/src/variation/translators/translator.py
@@ -6,7 +6,7 @@ from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.mappers import ManeTranscript
 from cool_seq_tool.schemas import AnnotationLayer, ManeGeneData, ResidueMode
 from cool_seq_tool.sources import UtaDatabase
-from ga4gh.core import entity_models
+from ga4gh.core.models import Extension
 from ga4gh.vrs import models
 
 from variation.hgvs_dup_del_mode import HGVSDupDelMode
@@ -258,7 +258,7 @@ class Translator(ABC):
     @staticmethod
     def _mane_gene_extensions(
         mane_genes: list[ManeGeneData],
-    ) -> list[entity_models.Extension] | None:
+    ) -> list[Extension] | None:
         """Transform mane genes to list of extensions
 
         This is only used in Genomic translators
@@ -270,7 +270,7 @@ class Translator(ABC):
         mane_genes_exts = None
         if mane_genes:
             mane_genes_exts = [
-                entity_models.Extension(
+                Extension(
                     name="mane_genes",
                     value=mane_genes,
                 )

--- a/src/variation/utils.py
+++ b/src/variation/utils.py
@@ -8,7 +8,7 @@ from bioutils.sequences import aa1_to_aa3 as _aa1_to_aa3
 from bioutils.sequences import aa3_to_aa1 as _aa3_to_aa1
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.schemas import ResidueMode
-from ga4gh.core.models import MappableConcept
+from ga4gh.core.models import Coding, ConceptMapping, MappableConcept, Relation
 from ga4gh.vrs import models
 
 from variation.schemas.app_schemas import AmbiguousRegexType
@@ -237,3 +237,21 @@ def get_vrs_loc_seq(
     else:
         ref = None
     return ref or None  # get_reference_sequence can return empty str
+
+
+def get_copy_change(efo_code: models.CopyChange) -> MappableConcept:
+    """Get mappable concept for EFO code with exactMatch relation
+
+    :param efo_code: EFO code represented as a CURIE
+    :return: Mappable concept for EFO code with exactMatch relation
+
+    """
+    return MappableConcept(
+        primaryCode=efo_code,
+        mappings=[
+            ConceptMapping(
+                relation=Relation.EXACT_MATCH,
+                coding=Coding(code=efo_code, system="https://www.ebi.ac.uk/efo/"),
+            )
+        ],
+    )

--- a/src/variation/utils.py
+++ b/src/variation/utils.py
@@ -8,7 +8,7 @@ from bioutils.sequences import aa1_to_aa3 as _aa1_to_aa3
 from bioutils.sequences import aa3_to_aa1 as _aa3_to_aa1
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.schemas import ResidueMode
-from ga4gh.core import domain_models
+from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models
 
 from variation.schemas.app_schemas import AmbiguousRegexType
@@ -67,12 +67,12 @@ def _get_priority_sequence_location(
 
 
 def get_priority_sequence_location(
-    gene: domain_models.Gene, seqrepo_access: SeqRepoAccess
+    gene: MappableConcept, seqrepo_access: SeqRepoAccess
 ) -> dict | None:
     """Get prioritized sequence location from a gene
     Will prioritize NCBI and then Ensembl. GRCh38 will be chosen over GRCh37.
 
-    :param gene: GA4GH Core Gene
+    :param gene: Mappable Concept containing gene information
     :param seqrepo_access: Client to access seqrepo
     :return: Prioritized sequence location represented as a dictionary if found
     """

--- a/src/variation/utils.py
+++ b/src/variation/utils.py
@@ -239,12 +239,11 @@ def get_vrs_loc_seq(
     return ref or None  # get_reference_sequence can return empty str
 
 
-def get_copy_change(efo_code: models.CopyChange) -> MappableConcept:
+def get_copy_change_concept(efo_code: models.CopyChange) -> MappableConcept:
     """Get mappable concept for EFO code with exactMatch relation
 
     :param efo_code: EFO code represented as a CURIE
     :return: Mappable concept for EFO code with exactMatch relation
-
     """
     return MappableConcept(
         primaryCode=efo_code,

--- a/src/variation/vrs_representation.py
+++ b/src/variation/vrs_representation.py
@@ -2,7 +2,8 @@
 
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.schemas import AnnotationLayer, ResidueMode
-from ga4gh.core import entity_models, ga4gh_identify
+from ga4gh.core import ga4gh_identify
+from ga4gh.core.models import Extension
 from ga4gh.vrs import models, normalize
 from pydantic import ValidationError
 
@@ -97,7 +98,7 @@ class VRSRepresentation:
         sstate: models.LiteralSequenceExpression | models.ReferenceLengthExpression,
         alt_type: AltType,
         errors: list[str],
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict | None:
         """Create a VRS Allele object.
 
@@ -154,7 +155,7 @@ class VRSRepresentation:
         cds_start: int | None = None,
         alt: str | None = None,
         residue_mode: ResidueMode = ResidueMode.RESIDUE,
-        extensions: list[entity_models.Extension] | None = None,
+        extensions: list[Extension] | None = None,
     ) -> dict | None:
         """Translate accession and position to VRS Allele Object.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from gene.query import QueryHandler as GeneQueryHandler
 
 from variation.classify import Classify
 from variation.query import QueryHandler
+from variation.schemas.normalize_response_schema import NormalizeService
 from variation.tokenize import Tokenize
 from variation.tokenizers import GeneSymbol
 
@@ -606,6 +607,21 @@ def _vrs_id_and_digest_existence_checks(vrs_obj_dict, prefix=None):
     assert location_vrs_id == f"ga4gh:SL.{location_vrs_digest}"
 
 
+def _mane_gene_ext_checks(actual_vo: dict) -> None:
+    """Check mane gene extensions existence
+
+    :param actual_vo: Actual VRS object represented as a dictionary
+    """
+    extensions = actual_vo.pop("extensions")
+    assert len(extensions) == 1
+
+    mane_genes_ext = extensions[0]
+    assert mane_genes_ext["name"] == "mane_genes"
+    for mane_gene in mane_genes_ext["value"]:
+        assert mane_gene["ncbi_gene_id"]
+        assert mane_gene["symbol"]
+
+
 def assertion_checks(
     normalize_response, test_variation, mane_genes_exts=False, check_vrs_id=False
 ):
@@ -616,14 +632,7 @@ def assertion_checks(
 
     # Check MANE genes existence
     if mane_genes_exts:
-        extensions = actual.pop("extensions")
-        assert len(extensions) == 1
-
-        mane_genes_ext = extensions[0]
-        assert mane_genes_ext["name"] == "mane_genes"
-        for mane_gene in mane_genes_ext["value"]:
-            assert mane_gene["ncbi_gene_id"]
-            assert mane_gene["symbol"]
+        _mane_gene_ext_checks(actual)
 
     expected = test_variation.model_copy().model_dump(exclude_none=True)
     if not check_vrs_id:
@@ -633,21 +642,50 @@ def assertion_checks(
     assert actual == expected, "variation"
 
 
-def cnv_assertion_checks(resp, test_fixture, check_vrs_id=False):
+def cnv_assertion_checks(resp, test_fixture, check_vrs_id=False, mane_genes_exts=False):
     """Check that actual response for to copy number matches expected"""
-    try:
-        cnc = resp.copy_number_count
-    except AttributeError:
-        actual = resp.copy_number_change.model_dump(exclude_none=True)
-        prefix = "ga4gh:CX."
+
+    def _update_expected_mappings(expected_):
+        """Modify test fixture copy to include mappable concept object for CX var"""
+        expected_["copyChange"]["mappings"] = [
+            {
+                "relation": "exactMatch",
+                "coding": {
+                    "system": "https://www.ebi.ac.uk/efo/",
+                    "code": expected_["copyChange"]["primaryCode"],
+                },
+            }
+        ]
+
+    expected = test_fixture.model_copy(deep=True).model_dump(exclude_none=True)
+
+    if isinstance(resp, NormalizeService):
+        actual = resp.variation
+        if isinstance(actual, models.CopyNumberChange):
+            _update_expected_mappings(expected)
+            prefix = "ga4gh:CX."
+        elif isinstance(actual, models.CopyNumberCount):
+            prefix = "ga4gh:CN."
+
+        actual = actual.model_dump(exclude_none=True)
     else:
-        actual = cnc.model_dump(exclude_none=True)
-        prefix = "ga4gh:CN."
+        try:
+            cnc = resp.copy_number_count
+        except AttributeError:
+            _update_expected_mappings(expected)
+            actual = resp.copy_number_change.model_dump(exclude_none=True)
+            prefix = "ga4gh:CX."
+        else:
+            actual = cnc.model_dump(exclude_none=True)
+            prefix = "ga4gh:CN."
+
+    # Check MANE genes existence
+    if mane_genes_exts:
+        _mane_gene_ext_checks(actual)
 
     if not check_vrs_id:
         _vrs_id_and_digest_existence_checks(actual, prefix=prefix)
 
-    expected = test_fixture.model_copy().model_dump(exclude_none=True)
     if not check_vrs_id:
         _delete_id_and_digest(expected)
         _delete_id_and_digest(expected["location"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -542,12 +542,12 @@ def grch38_genomic_insertion_variation(grch38_genomic_insertion_seq_loc):
 @pytest.fixture(scope="session")
 def braf_amplification(braf_ncbi_seq_loc):
     """Create test fixture for BRAF Amplification"""
-    digest = "_UsXDMCLtPwsVKiNByhbwfS569K1wLWW"
+    digest = "uPQaLz6KSwXWdsjNUZ5kRn3znBZF5YwV"
     params = {
         "id": f"ga4gh:CX.{digest}",
         "digest": digest,
         "location": braf_ncbi_seq_loc,
-        "copyChange": "efo:0030072",
+        "copyChange": {"primaryCode": "EFO:0030072"},
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -558,7 +558,7 @@ def prpf8_amplification(prpf8_ncbi_seq_loc):
     """Create test fixture for PRPF8 Amplification"""
     params = {
         "location": prpf8_ncbi_seq_loc,
-        "copyChange": "efo:0030072",
+        "copyChange": {"primaryCode": "EFO:0030072"},
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)

--- a/tests/fixtures/translators.yml
+++ b/tests/fixtures/translators.yml
@@ -1156,7 +1156,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 31120495],
                 "end": [33339477, null],
               },
-            "copyChange": "efo:0030067",
+            "copyChange": {"primaryCode":  "EFO:0030067"},
           },
         ]
     - query: NC_000023.10:g.(?_31138613)_(33357594_?)del
@@ -1175,7 +1175,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 31138612],
                 "end": [33357594, null],
               },
-            "copyChange": "efo:0030067",
+            "copyChange": {"primaryCode":  "EFO:0030067"},
           },
         ]
     - query: NC_000002.12:g.(?_110104900)_(110207160_?)del
@@ -1194,7 +1194,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 110104899],
                 "end": [110207160, null],
               },
-            "copyChange": "efo:0030067",
+            "copyChange": {"primaryCode":  "EFO:0030067"},
           },
         ]
     - query: NC_000024.10:g.(?_14076802)_(57165209_?)del
@@ -1213,7 +1213,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 14076801],
                 "end": [57165209, null],
               },
-            "copyChange": "efo:0030067",
+            "copyChange": {"primaryCode":  "EFO:0030067"},
           },
         ]
 
@@ -1288,7 +1288,7 @@ genomic_duplication_ambiguous:
                 "start": [31060226, 31100350],
                 "end": [33274278, 33417151],
               },
-            "copyChange": "efo:0030070",
+            "copyChange": {"primaryCode":  "EFO:0030070"},
           },
         ]
     - query: NC_000023.11:g.(?_154021812)_154092209dup
@@ -1307,7 +1307,7 @@ genomic_duplication_ambiguous:
                 "start": [null, 154021811],
                 "end": 154092209,
               },
-            "copyChange": "efo:0030070",
+            "copyChange": {"primaryCode":  "EFO:0030070"},
           },
         ]
     - query: NC_000020.11:g.(?_30417576)_(31394018_?)dup
@@ -1326,7 +1326,7 @@ genomic_duplication_ambiguous:
                 "start": [null, 30417575],
                 "end": [31394018, null],
               },
-            "copyChange": "efo:0030070",
+            "copyChange": {"primaryCode":  "EFO:0030070"},
           },
         ]
 
@@ -1348,6 +1348,6 @@ amplification:
                 "start": 140713327,
                 "end": 140924929,
               },
-            "copyChange": "efo:0030072",
+            "copyChange": {"primaryCode":  "EFO:0030072"},
           },
         ]

--- a/tests/fixtures/translators.yml
+++ b/tests/fixtures/translators.yml
@@ -781,12 +781,13 @@ protein_deletion:
                   },
                 "type": "SequenceLocation",
               },
-            "state": {
+            "state":
+              {
                 "type": "ReferenceLengthExpression",
                 "repeatSubunitLength": 5,
                 "length": 0,
                 "sequence": "",
-            },
+              },
             "type": "Allele",
           },
           {
@@ -801,12 +802,13 @@ protein_deletion:
                   },
                 "type": "SequenceLocation",
               },
-            "state": {
+            "state":
+              {
                 "type": "ReferenceLengthExpression",
                 "repeatSubunitLength": 5,
                 "length": 0,
                 "sequence": "",
-            },
+              },
             "type": "Allele",
           },
         ]
@@ -881,12 +883,13 @@ genomic_deletion:
                   },
                 "type": "SequenceLocation",
               },
-            "state": {
+            "state":
+              {
                 "type": "ReferenceLengthExpression",
                 "repeatSubunitLength": 2,
                 "length": 2,
                 "sequence": "AG",
-            },
+              },
             "type": "Allele",
           },
         ]
@@ -1134,7 +1137,10 @@ genomic_insertion:
                 "end": 7572948,
               },
             "state":
-              { "type": "LiteralSequenceExpression", "sequence": "TTTTTTTTTNNNNN" },
+              {
+                "type": "LiteralSequenceExpression",
+                "sequence": "TTTTTTTTTNNNNN",
+              },
           },
         ]
 
@@ -1156,7 +1162,21 @@ genomic_deletion_ambiguous:
                 "start": [null, 31120495],
                 "end": [33339477, null],
               },
-            "copyChange": {"primaryCode":  "EFO:0030067"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030067",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030067",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
     - query: NC_000023.10:g.(?_31138613)_(33357594_?)del
@@ -1175,7 +1195,21 @@ genomic_deletion_ambiguous:
                 "start": [null, 31138612],
                 "end": [33357594, null],
               },
-            "copyChange": {"primaryCode":  "EFO:0030067"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030067",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030067",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
     - query: NC_000002.12:g.(?_110104900)_(110207160_?)del
@@ -1194,7 +1228,21 @@ genomic_deletion_ambiguous:
                 "start": [null, 110104899],
                 "end": [110207160, null],
               },
-            "copyChange": {"primaryCode":  "EFO:0030067"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030067",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030067",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
     - query: NC_000024.10:g.(?_14076802)_(57165209_?)del
@@ -1213,7 +1261,21 @@ genomic_deletion_ambiguous:
                 "start": [null, 14076801],
                 "end": [57165209, null],
               },
-            "copyChange": {"primaryCode":  "EFO:0030067"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030067",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030067",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
 
@@ -1288,7 +1350,21 @@ genomic_duplication_ambiguous:
                 "start": [31060226, 31100350],
                 "end": [33274278, 33417151],
               },
-            "copyChange": {"primaryCode":  "EFO:0030070"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030070",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030070",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
     - query: NC_000023.11:g.(?_154021812)_154092209dup
@@ -1307,7 +1383,21 @@ genomic_duplication_ambiguous:
                 "start": [null, 154021811],
                 "end": 154092209,
               },
-            "copyChange": {"primaryCode":  "EFO:0030070"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030070",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030070",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
     - query: NC_000020.11:g.(?_30417576)_(31394018_?)dup
@@ -1326,7 +1416,21 @@ genomic_duplication_ambiguous:
                 "start": [null, 30417575],
                 "end": [31394018, null],
               },
-            "copyChange": {"primaryCode":  "EFO:0030070"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030070",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030070",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]
 
@@ -1348,6 +1452,20 @@ amplification:
                 "start": 140713327,
                 "end": 140924929,
               },
-            "copyChange": {"primaryCode":  "EFO:0030072"},
+            "copyChange":
+              {
+                "primaryCode": "EFO:0030072",
+                "mappings":
+                  [
+                    {
+                      "relation": "exactMatch",
+                      "coding":
+                        {
+                          "code": "EFO:0030072",
+                          "system": "https://www.ebi.ac.uk/efo/",
+                        },
+                    },
+                  ],
+              },
           },
         ]

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -3,7 +3,7 @@
 import pytest
 from ga4gh.vrs import models
 
-from tests.conftest import assertion_checks
+from tests.conftest import assertion_checks, cnv_assertion_checks
 from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 
 
@@ -771,14 +771,16 @@ async def test_genomic_dup1(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup1_38_cn, check_vrs_id=True, mane_genes_exts=True)
+    cnv_assertion_checks(
+        resp, genomic_dup1_38_cn, check_vrs_id=True, mane_genes_exts=True
+    )
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030072,
     )
-    assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True, mane_genes_exts=True)
@@ -790,14 +792,16 @@ async def test_genomic_dup1(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup1_38_cn, check_vrs_id=True, mane_genes_exts=True)
+    cnv_assertion_checks(
+        resp, genomic_dup1_38_cn, check_vrs_id=True, mane_genes_exts=True
+    )
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030072,
     )
-    assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_dup1_lse, check_vrs_id=True, mane_genes_exts=True)
@@ -813,7 +817,7 @@ async def test_genomic_dup1(
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_dup1_free_text_cn, mane_genes_exts=True)
+        cnv_assertion_checks(resp, genomic_dup1_free_text_cn, mane_genes_exts=True)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         assertion_checks(resp, genomic_dup1_free_text_lse, mane_genes_exts=True)
@@ -847,10 +851,10 @@ async def test_genomic_dup2(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup2_38_cn, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_dup2_38_cn, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup2_cx, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_dup2_cx, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_dup2_lse, mane_genes_exts=True)
@@ -862,10 +866,10 @@ async def test_genomic_dup2(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup2_38_cn, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_dup2_38_cn, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup2_cx, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_dup2_cx, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_dup2_lse, mane_genes_exts=True)
@@ -878,7 +882,7 @@ async def test_genomic_dup2(
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_dup2_free_text_cn, mane_genes_exts=True)
+        cnv_assertion_checks(resp, genomic_dup2_free_text_cn, mane_genes_exts=True)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         assertion_checks(resp, genomic_dup2_free_text_default, mane_genes_exts=True)
@@ -909,34 +913,34 @@ async def test_genomic_dup3(
     """Test that genomic duplication works correctly."""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup3_cx)
+    cnv_assertion_checks(resp, genomic_dup3_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=1
     )
-    assertion_checks(resp, genomic_del3_dup3_cn_38)
+    cnv_assertion_checks(resp, genomic_del3_dup3_cn_38)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030070,
     )
-    assertion_checks(resp, genomic_dup3_cx)
+    cnv_assertion_checks(resp, genomic_dup3_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup3_cx)
+    cnv_assertion_checks(resp, genomic_dup3_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=1
     )
-    assertion_checks(resp, genomic_del3_dup3_cn_38)
+    cnv_assertion_checks(resp, genomic_del3_dup3_cn_38)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup3_cx)
+    cnv_assertion_checks(resp, genomic_dup3_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -944,12 +948,12 @@ async def test_genomic_dup3(
     # Free Text
     for q in ["DMD g.(31147274_31147278)_(31182737_31182739)dup"]:  # 38
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_dup3_free_text_cx)
+        cnv_assertion_checks(resp, genomic_dup3_free_text_cx)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=3
         )
-        assertion_checks(resp, genomic_dup3_free_text_cn)
+        cnv_assertion_checks(resp, genomic_dup3_free_text_cn)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -974,30 +978,30 @@ async def test_genomic_dup4(
     """Test that genomic duplication works correctly."""
     q = "NC_000020.11:g.(?_30417576)_(31394018_?)dup"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup4_cx)
+    cnv_assertion_checks(resp, genomic_dup4_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup4_cn)
+    cnv_assertion_checks(resp, genomic_dup4_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup4_cx)
+    cnv_assertion_checks(resp, genomic_dup4_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup4_cx)
+    cnv_assertion_checks(resp, genomic_dup4_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup4_cn)
+    cnv_assertion_checks(resp, genomic_dup4_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup4_cx)
+    cnv_assertion_checks(resp, genomic_dup4_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -1008,12 +1012,12 @@ async def test_genomic_dup4(
         "PRPF8 g.(?_1674442)_(1684571_?)dup",  # 38
     ]:
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_dup4_free_text_cx)
+        cnv_assertion_checks(resp, genomic_dup4_free_text_cx)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_dup4_free_text_cn)
+        cnv_assertion_checks(resp, genomic_dup4_free_text_cn)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -1036,30 +1040,30 @@ async def test_genomic_dup5(
     """Test that genomic duplication works correctly."""
     q = "NC_000023.11:g.(?_154021812)_154092209dup"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup5_cx)
+    cnv_assertion_checks(resp, genomic_dup5_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup5_cn)
+    cnv_assertion_checks(resp, genomic_dup5_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup5_cx)
+    cnv_assertion_checks(resp, genomic_dup5_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup5_cx)
+    cnv_assertion_checks(resp, genomic_dup5_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_dup5_cn)
+    cnv_assertion_checks(resp, genomic_dup5_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup5_cx)
+    cnv_assertion_checks(resp, genomic_dup5_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -1070,12 +1074,12 @@ async def test_genomic_dup5(
         "MECP2 g.(?_154021812)_154092209dup",  # 38
     ]:
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_dup5_cx)
+        cnv_assertion_checks(resp, genomic_dup5_cx)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_dup5_cn)
+        cnv_assertion_checks(resp, genomic_dup5_cn)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -1100,30 +1104,30 @@ async def test_genomic_dup6(
     """Test that genomic duplication works correctly."""
     q = "NC_000023.11:g.154021812_(154092209_?)dup"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup6_cx)
+    cnv_assertion_checks(resp, genomic_dup6_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=1
     )
-    assertion_checks(resp, genomic_dup6_cn)
+    cnv_assertion_checks(resp, genomic_dup6_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup6_cx)
+    cnv_assertion_checks(resp, genomic_dup6_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_dup6_cx)
+    cnv_assertion_checks(resp, genomic_dup6_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=1
     )
-    assertion_checks(resp, genomic_dup6_cn)
+    cnv_assertion_checks(resp, genomic_dup6_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_dup6_cx)
+    cnv_assertion_checks(resp, genomic_dup6_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -1134,12 +1138,12 @@ async def test_genomic_dup6(
         "MECP2 g.154021812_(154092209_?)dup",  # 38
     ]:
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_dup6_cx)
+        cnv_assertion_checks(resp, genomic_dup6_cx)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=1
         )
-        assertion_checks(resp, genomic_dup6_cn)
+        cnv_assertion_checks(resp, genomic_dup6_cn)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -1172,14 +1176,14 @@ async def test_genomic_del1(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del1_38_cn, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del1_38_cn, mane_genes_exts=True)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030064,
     )
-    assertion_checks(resp, genomic_del1_cx, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del1_cx, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_del1_lse, mane_genes_exts=True)
@@ -1191,14 +1195,14 @@ async def test_genomic_del1(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del1_38_cn, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del1_38_cn, mane_genes_exts=True)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030064,
     )
-    assertion_checks(resp, genomic_del1_cx, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del1_cx, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_del1_lse, mane_genes_exts=True)
@@ -1211,7 +1215,7 @@ async def test_genomic_del1(
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_del1_free_text_cn, mane_genes_exts=True)
+        cnv_assertion_checks(resp, genomic_del1_free_text_cn, mane_genes_exts=True)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         assertion_checks(resp, genomic_del1_free_text_lse, mane_genes_exts=True)
@@ -1244,14 +1248,14 @@ async def test_genomic_del2(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del2_38_cn, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del2_38_cn, mane_genes_exts=True)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030069,
     )
-    assertion_checks(resp, genomic_del2_cx, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del2_cx, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_del2_lse, mane_genes_exts=True)
@@ -1263,14 +1267,14 @@ async def test_genomic_del2(
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del2_38_cn, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del2_38_cn, mane_genes_exts=True)
 
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
         copy_change=models.CopyChange.EFO_0030069,
     )
-    assertion_checks(resp, genomic_del2_cx, mane_genes_exts=True)
+    cnv_assertion_checks(resp, genomic_del2_cx, mane_genes_exts=True)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     assertion_checks(resp, genomic_del2_lse, mane_genes_exts=True)
@@ -1283,7 +1287,7 @@ async def test_genomic_del2(
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_del2_free_text_cnv, mane_genes_exts=True)
+        cnv_assertion_checks(resp, genomic_del2_free_text_cnv, mane_genes_exts=True)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         assertion_checks(resp, genomic_del2_free_text_default, mane_genes_exts=True)
@@ -1323,30 +1327,30 @@ async def test_genomic_del3(
     """Test that genomic deletion works correctly."""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)del"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del3_cx)
+    cnv_assertion_checks(resp, genomic_del3_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=3
     )
-    assertion_checks(resp, genomic_del3_dup3_cn_38)
+    cnv_assertion_checks(resp, genomic_del3_dup3_cn_38)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del3_cx)
+    cnv_assertion_checks(resp, genomic_del3_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del3_cx)
+    cnv_assertion_checks(resp, genomic_del3_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=3
     )
-    assertion_checks(resp, genomic_del3_dup3_cn_38)
+    cnv_assertion_checks(resp, genomic_del3_dup3_cn_38)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del3_cx)
+    cnv_assertion_checks(resp, genomic_del3_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -1357,12 +1361,12 @@ async def test_genomic_del3(
         "EFNB1 g.(68839265_68839268)_(68841120_68841125)del",  # 38
     ]:
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_del3_free_text_cx)
+        cnv_assertion_checks(resp, genomic_del3_free_text_cx)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=3
         )
-        assertion_checks(resp, genomic_del3_free_text_cn)
+        cnv_assertion_checks(resp, genomic_del3_free_text_cn)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -1390,51 +1394,51 @@ async def test_genomic_del4(
     """Test that genomic deletion works correctly."""
     q = "NC_000023.11:g.(?_31120496)_(33339477_?)del"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del4_cx)
+    cnv_assertion_checks(resp, genomic_del4_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del4_cn)
+    cnv_assertion_checks(resp, genomic_del4_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del4_cx)
+    cnv_assertion_checks(resp, genomic_del4_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del4_cx)
+    cnv_assertion_checks(resp, genomic_del4_cx)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del4_cn)
+    cnv_assertion_checks(resp, genomic_del4_cn)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del4_cx)
+    cnv_assertion_checks(resp, genomic_del4_cx)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000002.12:g.(?_110104900)_(110207160_?)del"
     resp = await test_handler.normalize(q)
-    assertion_checks(resp, genomic_uncertain_del_2)
+    cnv_assertion_checks(resp, genomic_uncertain_del_2)
 
     q = "NC_000024.10:g.(?_14076802)_(57165209_?)del"
     resp = await test_handler.normalize(q)
-    assertion_checks(resp, genomic_uncertain_del_y)
+    cnv_assertion_checks(resp, genomic_uncertain_del_y)
 
     # Free Text
     for q in ["COL4A4 g.(?_227022028)_(227025830_?)del"]:  # 38
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_del4_free_text_cx)
+        cnv_assertion_checks(resp, genomic_del4_free_text_cx)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_del4_free_text_cn)
+        cnv_assertion_checks(resp, genomic_del4_free_text_cn)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -1458,30 +1462,30 @@ async def test_genomic_del5(
     """Test that genomic deletion works correctly."""
     q = "NC_000023.11:g.(?_18575354)_18653629del"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del5_cx_var)
+    cnv_assertion_checks(resp, genomic_del5_cx_var)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=4
     )
-    assertion_checks(resp, genomic_del5_cn_var)
+    cnv_assertion_checks(resp, genomic_del5_cn_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del5_cx_var)
+    cnv_assertion_checks(resp, genomic_del5_cx_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del5_cx_var)
+    cnv_assertion_checks(resp, genomic_del5_cx_var)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=4
     )
-    assertion_checks(resp, genomic_del5_cn_var)
+    cnv_assertion_checks(resp, genomic_del5_cn_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del5_cx_var)
+    cnv_assertion_checks(resp, genomic_del5_cx_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -1489,12 +1493,12 @@ async def test_genomic_del5(
     # Free text
     for q in ["CDKL5 g.(?_18575354)_18653629del"]:
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_del5_cx_var)
+        cnv_assertion_checks(resp, genomic_del5_cx_var)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=4
         )
-        assertion_checks(resp, genomic_del5_cn_var)
+        cnv_assertion_checks(resp, genomic_del5_cn_var)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)
@@ -1519,30 +1523,30 @@ async def test_genomic_del6(
     """Test that genomic deletion works correctly."""
     q = "NC_000006.12:g.133462764_(133464858_?)del"  # 38
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del6_cx_var)
+    cnv_assertion_checks(resp, genomic_del6_cx_var)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del6_cn_var)
+    cnv_assertion_checks(resp, genomic_del6_cn_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del6_cx_var)
+    cnv_assertion_checks(resp, genomic_del6_cx_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-    assertion_checks(resp, genomic_del6_cx_var)
+    cnv_assertion_checks(resp, genomic_del6_cx_var)
 
     resp = await test_handler.normalize(
         q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
     )
-    assertion_checks(resp, genomic_del6_cn_var)
+    cnv_assertion_checks(resp, genomic_del6_cn_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.COPY_NUMBER_CHANGE)
-    assertion_checks(resp, genomic_del6_cx_var)
+    cnv_assertion_checks(resp, genomic_del6_cx_var)
 
     resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
     no_variation_check(resp, q)
@@ -1550,12 +1554,12 @@ async def test_genomic_del6(
     # Free text
     for q in ["EYA4 g.133462764_(133464858_?)del"]:  # 38
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.DEFAULT)
-        assertion_checks(resp, genomic_del6_cx_var)
+        cnv_assertion_checks(resp, genomic_del6_cx_var)
 
         resp = await test_handler.normalize(
             q, HGVSDupDelModeOption.COPY_NUMBER_COUNT, baseline_copies=2
         )
-        assertion_checks(resp, genomic_del6_cn_var)
+        cnv_assertion_checks(resp, genomic_del6_cn_var)
 
         resp = await test_handler.normalize(q, HGVSDupDelModeOption.ALLELE)
         no_variation_check(resp, q)

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -35,13 +35,13 @@ def genomic_dup1_lse(genomic_dup1_seq_loc_normalized):
 @pytest.fixture(scope="module")
 def genomic_dup1_cx(genomic_dup1_seq_loc_not_normalized):
     """Create a test fixture for genomic dup copy number change."""
-    digest = "yHUIaSwa0aIRvhfiTUIHPTkjNdaQdN4P"
+    digest = "GU4QwgBqWmlwshiv6CCtvynDEHkHBVv2"
     params = {
         "type": "CopyNumberChange",
         "id": f"ga4gh:CX.{digest}",
         "digest": digest,
         "location": genomic_dup1_seq_loc_not_normalized,
-        "copyChange": "efo:0030072",
+        "copyChange": {"primaryCode": "EFO:0030072"},
     }
     return models.CopyNumberChange(**params)
 
@@ -125,7 +125,7 @@ def genomic_dup2_cx(genomic_dup2_seq_loc_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup2_seq_loc_normalized,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -208,7 +208,7 @@ def genomic_dup3_cx(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -233,7 +233,7 @@ def genomic_dup3_free_text_cx(genomic_dup3_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup3_free_text_subject,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -255,7 +255,7 @@ def genomic_dup4_cx(genomic_dup4_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_loc,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -291,7 +291,7 @@ def genomic_dup4_free_text_cx(genomic_dup4_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_free_text_subject,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -313,7 +313,7 @@ def genomic_dup5_cx(genomic_dup5_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup5_loc,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -335,7 +335,7 @@ def genomic_dup6_cx(genomic_dup6_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup6_loc,
-        "copyChange": "efo:0030070",
+        "copyChange": {"primaryCode": "EFO:0030070"},
     }
     return models.CopyNumberChange(**params)
 
@@ -373,7 +373,7 @@ def genomic_del1_cx(genomic_del1_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del1_seq_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -488,7 +488,7 @@ def genomic_del2_cx(genomic_del2_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del2_seq_loc,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -556,7 +556,7 @@ def genomic_del3_cx(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -581,7 +581,7 @@ def genomic_del3_free_text_cx(genomic_del3_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_free_text_subject,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -603,7 +603,7 @@ def genomic_del4_cx(genomic_del4_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_seq_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -639,7 +639,7 @@ def genomic_del4_free_text_cx(genomic_del4_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_free_text_subject,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -668,7 +668,7 @@ def genomic_uncertain_del_2():
             "end": [110207160, None],
             "type": "SequenceLocation",
         },
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -687,7 +687,7 @@ def genomic_uncertain_del_y():
             "end": [57165209, None],
             "type": "SequenceLocation",
         },
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -710,7 +710,7 @@ def genomic_del5_cx_var(genomic_del5_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del5_seq_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -721,7 +721,7 @@ def genomic_del6_cx_var(genomic_del6_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del6_seq_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pytest
 from ga4gh.vrs import models
 
-from tests.conftest import assertion_checks
+from tests.conftest import assertion_checks, cnv_assertion_checks
 from variation.main import normalize as normalize_get_response
 from variation.main import to_vrs as to_vrs_get_response
 from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
@@ -865,12 +865,12 @@ async def test_amplification(test_handler, braf_amplification, prpf8_amplificati
     """Test that amplification normalizes correctly."""
     q = "BRAF Amplification"
     resp = await test_handler.normalize(q)
-    assertion_checks(resp, braf_amplification, check_vrs_id=True)
+    cnv_assertion_checks(resp, braf_amplification, check_vrs_id=True)
 
     # Gene with > 1 sequence location
     q = "PRPF8 AMPLIFICATION"
     resp = await test_handler.normalize(q)
-    assertion_checks(resp, prpf8_amplification)
+    cnv_assertion_checks(resp, prpf8_amplification)
 
     # Gene with no location. This should NOT return a variation
     resp = await test_handler.normalize("IFNR amplification")

--- a/tests/to_copy_number_variation/test_amplification_to_cx_var.py
+++ b/tests/to_copy_number_variation/test_amplification_to_cx_var.py
@@ -11,7 +11,7 @@ def kit_amplification():
     params = {
         "type": "CopyNumberChange",
         "id": "ga4gh:CX.8ENbdAlnf3hK6681-74YhcnfD-J6WQbN",
-        "copyChange": "efo:0030072",
+        "copyChange": {"primaryCode": "EFO:0030072"},
         "location": {
             "type": "SequenceLocation",
             "id": "ga4gh:SL.2xCHxtZBqOXxl4W4ACxq9Um4FqcqZKxL",

--- a/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
@@ -8,13 +8,13 @@ from tests.conftest import cnv_assertion_checks
 @pytest.fixture(scope="module")
 def genomic_dup1_cx_38(genomic_dup1_seq_loc_not_normalized):
     """Create test fixture copy number change variation"""
-    digest = "Zzws_y4cnoooQ7WXjg2B3nKIyFWXzOg3"
+    digest = "30bDl5yhHzjc4M5uGS_8IeYMzHQksQGh"
     params = {
         "type": "CopyNumberChange",
         "id": f"ga4gh:CX.{digest}",
         "digest": digest,
         "location": genomic_dup1_seq_loc_not_normalized,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -51,7 +51,7 @@ def genomic_dup1_cx_37(genomic_dup1_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup1_37_loc,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -62,7 +62,7 @@ def genomic_dup2_cx_38(genomic_dup2_seq_loc_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup2_seq_loc_normalized,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -99,7 +99,7 @@ def genomic_dup2_cx_37(genomic_dup2_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup2_37_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -110,7 +110,7 @@ def genomic_dup3_cx_38(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": "efo:0030072",
+        "copyChange": {"primaryCode": "EFO:0030072"},
     }
     return models.CopyNumberChange(**params)
 
@@ -146,7 +146,7 @@ def genomic_dup3_cx_37(genomic_dup3_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup3_37_loc,
-        "copyChange": "efo:0030072",
+        "copyChange": {"primaryCode": "EFO:0030072"},
     }
     return models.CopyNumberChange(**params)
 
@@ -168,7 +168,7 @@ def genomic_dup4_cx_38(genomic_dup4_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_loc,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -204,7 +204,7 @@ def genomic_dup4_cx_37(genomic_dup4_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_37_loc,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -226,7 +226,7 @@ def genomic_dup5_cx_38(genomic_dup5_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup5_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -262,7 +262,7 @@ def genomic_dup5_cx_37(genomic_dup5_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup5_37_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -284,7 +284,7 @@ def genomic_dup6_cx_38(genomic_dup6_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup6_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -320,7 +320,7 @@ def genomic_dup6_cx_37(genomic_dup6_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup6_37_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -331,7 +331,7 @@ def genomic_del1_cx_38(genomic_del1_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del1_seq_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -368,7 +368,7 @@ def genomic_del1_cx_37(genomic_del1_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del1_37_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -379,7 +379,7 @@ def genomic_del2_cx_38(genomic_del2_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del2_seq_loc,
-        "copyChange": "efo:0030071",
+        "copyChange": {"primaryCode": "EFO:0030071"},
     }
     return models.CopyNumberChange(**params)
 
@@ -416,7 +416,7 @@ def genomic_del2_cx_37(genomic_del2_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del2_37_loc,
-        "copyChange": "efo:0030071",
+        "copyChange": {"primaryCode": "EFO:0030071"},
     }
     return models.CopyNumberChange(**params)
 
@@ -427,7 +427,7 @@ def genomic_del3_cx_38(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -452,7 +452,7 @@ def genomic_del3_cx_37(genomic_del3_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_37_loc,
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**params)
 
@@ -474,7 +474,7 @@ def genomic_del4_cx_38(genomic_del4_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_seq_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -510,7 +510,7 @@ def genomic_del4_cx_37(genomic_del4_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_37_loc,
-        "copyChange": "efo:0030067",
+        "copyChange": {"primaryCode": "EFO:0030067"},
     }
     return models.CopyNumberChange(**params)
 
@@ -532,7 +532,7 @@ def genomic_del5_cx_38(genomic_del5_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del5_seq_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -568,7 +568,7 @@ def genomic_del5_cx_37(genomic_del5_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del5_37_loc,
-        "copyChange": "efo:0030064",
+        "copyChange": {"primaryCode": "EFO:0030064"},
     }
     return models.CopyNumberChange(**params)
 
@@ -590,7 +590,7 @@ def genomic_del6_cx_38(genomic_del6_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del6_seq_loc,
-        "copyChange": "efo:0030071",
+        "copyChange": {"primaryCode": "EFO:0030071"},
     }
     return models.CopyNumberChange(**params)
 
@@ -626,7 +626,7 @@ def genomic_del6_cx_37(genomic_del6_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del6_37_loc,
-        "copyChange": "efo:0030071",
+        "copyChange": {"primaryCode": "EFO:0030071"},
     }
     return models.CopyNumberChange(**params)
 
@@ -663,18 +663,18 @@ async def test_genomic_dup1_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000003.12:g.49531262dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=False
+        q, copy_change="EFO:0030069", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup1_cx_38, check_vrs_id=True)
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=False
+        q, copy_change="EFO:0030069", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup1_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=True
+        q, copy_change="EFO:0030069", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup1_cx_38)
 
@@ -709,18 +709,18 @@ async def test_genomic_dup2_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.33211290_33211293dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=False
+        q, copy_change="EFO:0030067", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup2_cx_38)
 
     q = "NC_000023.10:g.33229407_33229410dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=False
+        q, copy_change="EFO:0030067", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup2_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=True
+        q, copy_change="EFO:0030067", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup2_cx_38)
 
@@ -755,18 +755,18 @@ async def test_genomic_dup3_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030072", do_liftover=False
+        q, copy_change="EFO:0030072", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup3_cx_38)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030072", do_liftover=False
+        q, copy_change="EFO:0030072", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup3_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030072", do_liftover=True
+        q, copy_change="EFO:0030072", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup3_cx_38)
 
@@ -801,18 +801,18 @@ async def test_genomic_dup4_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000020.11:g.(?_30417576)_(31394018_?)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=False
+        q, copy_change="EFO:0030069", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup4_cx_38)
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=False
+        q, copy_change="EFO:0030069", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup4_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=True
+        q, copy_change="EFO:0030069", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup4_cx_38)
 
@@ -847,18 +847,18 @@ async def test_genomic_dup5_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(?_154021812)_154092209dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=False
+        q, copy_change="EFO:0030067", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup5_cx_38)
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=False
+        q, copy_change="EFO:0030067", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup5_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=True
+        q, copy_change="EFO:0030067", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup5_cx_38)
 
@@ -893,18 +893,18 @@ async def test_genomic_dup6_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.154021812_(154092209_?)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=False
+        q, copy_change="EFO:0030064", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup6_cx_38)
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=False
+        q, copy_change="EFO:0030064", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup6_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=True
+        q, copy_change="EFO:0030064", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup6_cx_38)
 
@@ -939,18 +939,18 @@ async def test_genomic_del1_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10149811del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=False
+        q, copy_change="EFO:0030064", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del1_cx_38)
 
     q = "NC_000003.11:g.10191495del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=False
+        q, copy_change="EFO:0030064", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del1_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=True
+        q, copy_change="EFO:0030064", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del1_cx_38)
 
@@ -985,18 +985,18 @@ async def test_genomic_del2_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10146595_10146613del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=False
+        q, copy_change="EFO:0030071", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del2_cx_38)
 
     q = "NC_000003.11:g.10188279_10188297del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=False
+        q, copy_change="EFO:0030071", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del2_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=True
+        q, copy_change="EFO:0030071", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del2_cx_38)
 
@@ -1031,18 +1031,18 @@ async def test_genomic_del3_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=False
+        q, copy_change="EFO:0030069", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del3_cx_38)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=False
+        q, copy_change="EFO:0030069", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del3_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030069", do_liftover=True
+        q, copy_change="EFO:0030069", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del3_cx_38)
 
@@ -1077,18 +1077,18 @@ async def test_genomic_del4_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_31120496)_(33339477_?)del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=False
+        q, copy_change="EFO:0030067", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del4_cx_38)
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=False
+        q, copy_change="EFO:0030067", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del4_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030067", do_liftover=True
+        q, copy_change="EFO:0030067", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del4_cx_38)
 
@@ -1123,18 +1123,18 @@ async def test_genomic_del5_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_18575354)_18653629del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=False
+        q, copy_change="EFO:0030064", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del5_cx_38)
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=False
+        q, copy_change="EFO:0030064", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del5_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030064", do_liftover=True
+        q, copy_change="EFO:0030064", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del5_cx_38)
 
@@ -1169,18 +1169,18 @@ async def test_genomic_del6_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000006.12:g.133462764_(133464858_?)del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=False
+        q, copy_change="EFO:0030071", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del6_cx_38)
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=False
+        q, copy_change="EFO:0030071", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del6_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=True
+        q, copy_change="EFO:0030071", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del6_cx_38)
 
@@ -1191,7 +1191,7 @@ async def test_invalid_cnv(test_cnv_handler):
     q = "DAG1 g.49568695dup"
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
         q,
-        copy_change="efo:0030071",
+        copy_change="EFO:0030071",
         do_liftover=True,
     )
     assert set(resp.warnings) == {
@@ -1201,7 +1201,7 @@ async def test_invalid_cnv(test_cnv_handler):
 
     q = "braf V600E"
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="efo:0030071", do_liftover=True
+        q, copy_change="EFO:0030071", do_liftover=True
     )
     assert set(resp.warnings) == {
         "braf V600E is not a supported HGVS genomic duplication or deletion"

--- a/tests/to_copy_number_variation/test_parsed_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_parsed_to_copy_number.py
@@ -152,7 +152,7 @@ def cn_definite_number():
 @pytest.fixture(scope="module")
 def cx_numbers():
     """Create test fixture for copy number change using numbers for start and end"""
-    cx_digest = "5kaJC-7Jj851bfJ6EipsHV413feg1T4T"
+    cx_digest = "XIsVHbhEUbXraIgpgV4ToCa-6oZWMRUD"
     loc_digest = "Iz_azSFTEulx7tCluLgGhE1n0hTLUocb"
     variation = {
         "type": "CopyNumberChange",
@@ -169,7 +169,7 @@ def cx_numbers():
             "start": 10000,
             "end": 1223133,
         },
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**variation)
 
@@ -190,7 +190,7 @@ def cx_definite_ranges():
             "start": [10000, 10005],
             "end": [1223130, 1223133],
         },
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**variation)
 
@@ -211,7 +211,7 @@ def cx_indefinite_ranges():
             "start": [None, 10000],
             "end": [1223130, None],
         },
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**variation)
 
@@ -232,7 +232,7 @@ def cx_number_indefinite():
             "start": 10000,
             "end": [1223130, None],
         },
-        "copyChange": "efo:0030069",
+        "copyChange": {"primaryCode": "EFO:0030069"},
     }
     return models.CopyNumberChange(**variation)
 
@@ -859,7 +859,7 @@ def test_invalid(test_cnv_handler):
             copy_change="efo:1234",
             accession="NC_000001.10",
         )
-    assert "Input should be 'efo:" in str(e.value)
+    assert "Input should be 'EFO:" in str(e.value)
 
     # NCBI36/hg18 assembly
     rb = ParsedToCxVarQuery(


### PR DESCRIPTION
close #581 

* Update modules to vrs [2.0.0-ballot.2024-11.3](https://github.com/ga4gh/vrs/tree/2.0.0-ballot.2024-11.3) tag
  * `CopyNumberChange` has `mappings` for EFO code 