### PR TITLE
feat!: update to vrs 2.0.1 models

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,8 +19,8 @@ ruff = "==0.5.0"
 fastapi = "*"
 uvicorn = "*"
 pydantic = "==2.*"
-"ga4gh.vrs" = {version = "==2.0.0a14", extras = ["extras"]}
-gene-normalizer = ">=0.8.0"
+"ga4gh.vrs" = {version = "==2.*", extras = ["extras"]}
+gene-normalizer = ">=0.9.0"
 boto3 = "*"
 cool-seq-tool = "~=0.13.0"
 bioutils = "*"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ python3 -m pip install variation-normalizer
 
 | variation-normalization branch | variation-normalizer version | gene-normalizer version | VRS version |
 | ---- | --- | ---- | --- |
-| [main](https://github.com/cancervariants/variation-normalization/tree/main) | >=0.11.Z | >=0.6.Z | [2.0.0-ballot.2024-11](https://github.com/ga4gh/vrs/tree/2.0.0-ballot.2024-11) |
+| [main](https://github.com/cancervariants/variation-normalization/tree/main) | >=0.14.Z | >=0.9.Z | [2.0](https://github.com/ga4gh/vrs/tree/2.0) |
 
 ## About
 
@@ -49,7 +49,7 @@ The variation-normalization repo depends on VRS models, and therefore each varia
 
 | variation-normalization branch | variation-normalizer version | gene-normalizer version | VRS version |
 | ---- | --- | ---- | --- |
-| [main](https://github.com/cancervariants/variation-normalization/tree/main) | >=0.11.Z | >=0.6.Z | [2.0.0-ballot.2024-11](https://github.com/ga4gh/vrs/tree/2.0.0-ballot.2024-11) |
+| [main](https://github.com/cancervariants/variation-normalization/tree/main) | >=0.14.Z | >=0.9.Z | [2.0](https://github.com/ga4gh/vrs/tree/2.0) |
 
 ### Previous VRS Versioning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "pydantic ==2.*",
-    "ga4gh.vrs[extras] ==2.0.0a14",
-    "gene-normalizer >=0.8.0",
+    "ga4gh.vrs[extras] ==2.*",
+    "gene-normalizer >=0.9.0",
     "boto3",
     "cool-seq-tool ~=0.13.0",
     "bioutils"

--- a/src/variation/hgvs_dup_del_mode.py
+++ b/src/variation/hgvs_dup_del_mode.py
@@ -10,7 +10,6 @@ from ga4gh.vrs import models, normalize
 
 from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 from variation.schemas.token_response_schema import AMBIGUOUS_REGIONS, AltType
-from variation.utils import get_copy_change_concept
 
 # Define deletion alt types
 DELS = {AltType.DELETION_AMBIGUOUS, AltType.DELETION}
@@ -138,16 +137,14 @@ class HGVSDupDelMode:
 
         if not copy_change:
             copy_change = (
-                models.CopyChange.EFO_0030067
-                if alt_type in DELS
-                else models.CopyChange.EFO_0030070
+                models.CopyChange.LOSS if alt_type in DELS else models.CopyChange.GAIN
             )
 
         seq_loc = models.SequenceLocation(**location)
         seq_loc.id = ga4gh_identify(seq_loc)
         cx = models.CopyNumberChange(
             location=seq_loc,
-            copyChange=get_copy_change_concept(copy_change),
+            copyChange=copy_change,
             extensions=extensions,
         )
         cx.id = ga4gh_identify(cx)

--- a/src/variation/schemas/copy_number_schema.py
+++ b/src/variation/schemas/copy_number_schema.py
@@ -324,8 +324,8 @@ class ParsedToCxVarService(ServiceResponse):
             "example": {
                 "copy_number_change": {
                     "type": "CopyNumberChange",
-                    "id": "ga4gh:CX.XIsVHbhEUbXraIgpgV4ToCa-6oZWMRUD",
-                    "digest": "XIsVHbhEUbXraIgpgV4ToCa-6oZWMRUD",
+                    "id": "ga4gh:CX.AikSAwyBq4t71coigYRGxcsvuWyAUU-8",
+                    "digest": "AikSAwyBq4t71coigYRGxcsvuWyAUU-8",
                     "location": {
                         "type": "SequenceLocation",
                         "id": "ga4gh:SL.Iz_azSFTEulx7tCluLgGhE1n0hTLUocb",
@@ -337,18 +337,7 @@ class ParsedToCxVarService(ServiceResponse):
                         "start": 10000,
                         "end": 1223133,
                     },
-                    "copyChange": {
-                        "primaryCode": "EFO:0030069",
-                        "mappings": [
-                            {
-                                "coding": {
-                                    "system": "https://www.ebi.ac.uk/efo/",
-                                    "code": "EFO:0030069",
-                                },
-                                "relation": "exactMatch",
-                            }
-                        ],
-                    },
+                    "copyChange": "complete genomic loss",
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",
@@ -390,8 +379,8 @@ class AmplificationToCxVarService(ServiceResponse):
                 },
                 "amplification_label": "BRAF Amplification",
                 "copy_number_change": {
-                    "id": "ga4gh:CX.uPQaLz6KSwXWdsjNUZ5kRn3znBZF5YwV",
-                    "digest": "uPQaLz6KSwXWdsjNUZ5kRn3znBZF5YwV",
+                    "id": "ga4gh:CX.h7unj-f_djER28-h2Q6Prvo3C90O4d3M",
+                    "digest": "h7unj-f_djER28-h2Q6Prvo3C90O4d3M",
                     "type": "CopyNumberChange",
                     "location": {
                         "id": "ga4gh:SL.0nPwKHYNnTmJ06G-gSmz8BEhB_NTp-0B",
@@ -404,18 +393,7 @@ class AmplificationToCxVarService(ServiceResponse):
                         "start": 140713327,
                         "end": 140924929,
                     },
-                    "copyChange": {
-                        "primaryCode": "EFO:0030072",
-                        "mappings": [
-                            {
-                                "coding": {
-                                    "system": "https://www.ebi.ac.uk/efo/",
-                                    "code": "EFO:0030072",
-                                },
-                                "relation": "exactMatch",
-                            }
-                        ],
-                    },
+                    "copyChange": "high-level gain",
                 },
                 "service_meta_": {
                     "version": __version__,

--- a/src/variation/schemas/hgvs_to_copy_number_schema.py
+++ b/src/variation/schemas/hgvs_to_copy_number_schema.py
@@ -56,8 +56,8 @@ class HgvsToCopyNumberChangeService(ServiceResponse):
             "example": {
                 "hgvs_expr": "NC_000003.12:g.49531262dup",
                 "copy_number_change": {
-                    "id": "ga4gh:CX.30bDl5yhHzjc4M5uGS_8IeYMzHQksQGh",
-                    "digest": "30bDl5yhHzjc4M5uGS_8IeYMzHQksQGh",
+                    "id": "ga4gh:CX.-PXHqkvTzdzEdLKzZ3Co7YysLSYuFShj",
+                    "digest": "-PXHqkvTzdzEdLKzZ3Co7YysLSYuFShj",
                     "type": "CopyNumberChange",
                     "location": {
                         "id": "ga4gh:SL.2vbgFGHGB0QGODwgZNi05fWbROkkjf04",
@@ -70,18 +70,7 @@ class HgvsToCopyNumberChangeService(ServiceResponse):
                         "start": 49531261,
                         "end": 49531262,
                     },
-                    "copyChange": {
-                        "primaryCode": "EFO:0030069",
-                        "mappings": [
-                            {
-                                "coding": {
-                                    "system": "https://www.ebi.ac.uk/efo/",
-                                    "code": "EFO:0030069",
-                                },
-                                "relation": "exactMatch",
-                            }
-                        ],
-                    },
+                    "copyChange": "complete genomic loss",
                 },
                 "service_meta_": {
                     "name": "variation-normalizer",

--- a/src/variation/to_copy_number_variation.py
+++ b/src/variation/to_copy_number_variation.py
@@ -43,7 +43,6 @@ from variation.to_vrs import ToVRS
 from variation.tokenize import Tokenize
 from variation.translate import Translate
 from variation.utils import (
-    get_copy_change_concept,
     get_priority_sequence_location,
     get_vrs_loc_seq,
 )
@@ -608,7 +607,7 @@ class ToCopyNumberVariation(ToVRS):
             if is_cx:
                 variation = models.CopyNumberChange(
                     location=seq_loc,
-                    copyChange=get_copy_change_concept(request_body.copy_change),
+                    copyChange=request_body.copy_change,
                 )
                 variation.id = ga4gh_identify(variation)
             else:
@@ -720,9 +719,7 @@ class ToCopyNumberVariation(ToVRS):
                     vrs_location.id = ga4gh_identify(vrs_location)
                     vrs_cx = models.CopyNumberChange(
                         location=vrs_location,
-                        copyChange=get_copy_change_concept(
-                            models.CopyChange.EFO_0030072
-                        ),
+                        copyChange=models.CopyChange.HIGH_LEVEL_GAIN,
                     )
                     vrs_cx.id = ga4gh_identify(vrs_cx)
                     variation = models.CopyNumberChange(

--- a/src/variation/translators/amplification.py
+++ b/src/variation/translators/amplification.py
@@ -9,7 +9,7 @@ from variation.schemas.normalize_response_schema import HGVSDupDelModeOption
 from variation.schemas.translation_response_schema import TranslationResult
 from variation.schemas.validation_response_schema import ValidationResult
 from variation.translators.translator import Translator
-from variation.utils import get_copy_change_concept, get_priority_sequence_location
+from variation.utils import get_priority_sequence_location
 
 
 class Amplification(Translator):
@@ -52,7 +52,7 @@ class Amplification(Translator):
         if priority_seq_loc:
             vrs_cx = models.CopyNumberChange(
                 location=models.SequenceLocation(**priority_seq_loc),
-                copyChange=get_copy_change_concept(models.CopyChange.EFO_0030072),
+                copyChange=models.CopyChange.HIGH_LEVEL_GAIN,
             )
             vrs_cx.id = ga4gh_identify(vrs_cx)
             vrs_cx = vrs_cx.model_dump(exclude_none=True)

--- a/src/variation/utils.py
+++ b/src/variation/utils.py
@@ -8,7 +8,7 @@ from bioutils.sequences import aa1_to_aa3 as _aa1_to_aa3
 from bioutils.sequences import aa3_to_aa1 as _aa3_to_aa1
 from cool_seq_tool.handlers import SeqRepoAccess
 from cool_seq_tool.schemas import CoordinateType
-from ga4gh.core.models import Coding, ConceptMapping, MappableConcept, Relation
+from ga4gh.core.models import MappableConcept
 from ga4gh.vrs import models
 
 from variation.schemas.app_schemas import AmbiguousRegexType
@@ -237,20 +237,3 @@ def get_vrs_loc_seq(
     else:
         ref = None
     return ref or None  # get_reference_sequence can return empty str
-
-
-def get_copy_change_concept(efo_code: models.CopyChange) -> MappableConcept:
-    """Get mappable concept for EFO code with exactMatch relation
-
-    :param efo_code: EFO code represented as a CURIE
-    :return: Mappable concept for EFO code with exactMatch relation
-    """
-    return MappableConcept(
-        primaryCode=efo_code,
-        mappings=[
-            ConceptMapping(
-                relation=Relation.EXACT_MATCH,
-                coding=Coding(code=efo_code, system="https://www.ebi.ac.uk/efo/"),
-            )
-        ],
-    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -543,12 +543,12 @@ def grch38_genomic_insertion_variation(grch38_genomic_insertion_seq_loc):
 @pytest.fixture(scope="session")
 def braf_amplification(braf_ncbi_seq_loc):
     """Create test fixture for BRAF Amplification"""
-    digest = "uPQaLz6KSwXWdsjNUZ5kRn3znBZF5YwV"
+    digest = "h7unj-f_djER28-h2Q6Prvo3C90O4d3M"
     params = {
         "id": f"ga4gh:CX.{digest}",
         "digest": digest,
         "location": braf_ncbi_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030072"},
+        "copyChange": "high-level gain",
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -559,7 +559,7 @@ def prpf8_amplification(prpf8_ncbi_seq_loc):
     """Create test fixture for PRPF8 Amplification"""
     params = {
         "location": prpf8_ncbi_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030072"},
+        "copyChange": "high-level gain",
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -645,25 +645,11 @@ def assertion_checks(
 
 def cnv_assertion_checks(resp, test_fixture, check_vrs_id=False, mane_genes_exts=False):
     """Check that actual response for to copy number matches expected"""
-
-    def _update_expected_mappings(expected_):
-        """Modify test fixture copy to include mappable concept object for CX var"""
-        expected_["copyChange"]["mappings"] = [
-            {
-                "relation": "exactMatch",
-                "coding": {
-                    "system": "https://www.ebi.ac.uk/efo/",
-                    "code": expected_["copyChange"]["primaryCode"],
-                },
-            }
-        ]
-
     expected = test_fixture.model_copy(deep=True).model_dump(exclude_none=True)
 
     if isinstance(resp, NormalizeService):
         actual = resp.variation
         if isinstance(actual, models.CopyNumberChange):
-            _update_expected_mappings(expected)
             prefix = "ga4gh:CX."
         elif isinstance(actual, models.CopyNumberCount):
             prefix = "ga4gh:CN."
@@ -673,7 +659,6 @@ def cnv_assertion_checks(resp, test_fixture, check_vrs_id=False, mane_genes_exts
         try:
             cnc = resp.copy_number_count
         except AttributeError:
-            _update_expected_mappings(expected)
             actual = resp.copy_number_change.model_dump(exclude_none=True)
             prefix = "ga4gh:CX."
         else:

--- a/tests/fixtures/translators.yml
+++ b/tests/fixtures/translators.yml
@@ -1162,21 +1162,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 31120495],
                 "end": [33339477, null],
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030067",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030067",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange": "loss",
           },
         ]
     - query: NC_000023.10:g.(?_31138613)_(33357594_?)del
@@ -1195,21 +1181,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 31138612],
                 "end": [33357594, null],
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030067",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030067",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange":"loss",
           },
         ]
     - query: NC_000002.12:g.(?_110104900)_(110207160_?)del
@@ -1228,21 +1200,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 110104899],
                 "end": [110207160, null],
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030067",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030067",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange": "loss",
           },
         ]
     - query: NC_000024.10:g.(?_14076802)_(57165209_?)del
@@ -1261,21 +1219,7 @@ genomic_deletion_ambiguous:
                 "start": [null, 14076801],
                 "end": [57165209, null],
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030067",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030067",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange": "loss",
           },
         ]
 
@@ -1350,21 +1294,7 @@ genomic_duplication_ambiguous:
                 "start": [31060226, 31100350],
                 "end": [33274278, 33417151],
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030070",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030070",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange":"gain",
           },
         ]
     - query: NC_000023.11:g.(?_154021812)_154092209dup
@@ -1383,21 +1313,7 @@ genomic_duplication_ambiguous:
                 "start": [null, 154021811],
                 "end": 154092209,
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030070",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030070",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange":"gain",
           },
         ]
     - query: NC_000020.11:g.(?_30417576)_(31394018_?)dup
@@ -1416,21 +1332,7 @@ genomic_duplication_ambiguous:
                 "start": [null, 30417575],
                 "end": [31394018, null],
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030070",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030070",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange":"gain",
           },
         ]
 
@@ -1452,20 +1354,6 @@ amplification:
                 "start": 140713327,
                 "end": 140924929,
               },
-            "copyChange":
-              {
-                "primaryCode": "EFO:0030072",
-                "mappings":
-                  [
-                    {
-                      "relation": "exactMatch",
-                      "coding":
-                        {
-                          "code": "EFO:0030072",
-                          "system": "https://www.ebi.ac.uk/efo/",
-                        },
-                    },
-                  ],
-              },
+            "copyChange":"high-level gain",
           },
         ]

--- a/tests/test_hgvs_dup_del_mode.py
+++ b/tests/test_hgvs_dup_del_mode.py
@@ -35,13 +35,13 @@ def genomic_dup1_lse(genomic_dup1_seq_loc_normalized):
 @pytest.fixture(scope="module")
 def genomic_dup1_cx(genomic_dup1_seq_loc_not_normalized):
     """Create a test fixture for genomic dup copy number change."""
-    digest = "GU4QwgBqWmlwshiv6CCtvynDEHkHBVv2"
+    digest = "LoyMVDQ2uoTjpHukDh12-nOJyoWTmHKG"
     params = {
         "type": "CopyNumberChange",
         "id": f"ga4gh:CX.{digest}",
         "digest": digest,
         "location": genomic_dup1_seq_loc_not_normalized,
-        "copyChange": {"primaryCode": "EFO:0030072"},
+        "copyChange": "high-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -125,7 +125,7 @@ def genomic_dup2_cx(genomic_dup2_seq_loc_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup2_seq_loc_normalized,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -208,7 +208,7 @@ def genomic_dup3_cx(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -233,7 +233,7 @@ def genomic_dup3_free_text_cx(genomic_dup3_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup3_free_text_subject,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -255,7 +255,7 @@ def genomic_dup4_cx(genomic_dup4_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_loc,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -291,7 +291,7 @@ def genomic_dup4_free_text_cx(genomic_dup4_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_free_text_subject,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -313,7 +313,7 @@ def genomic_dup5_cx(genomic_dup5_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup5_loc,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -335,7 +335,7 @@ def genomic_dup6_cx(genomic_dup6_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup6_loc,
-        "copyChange": {"primaryCode": "EFO:0030070"},
+        "copyChange": "gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -373,7 +373,7 @@ def genomic_del1_cx(genomic_del1_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del1_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -488,7 +488,7 @@ def genomic_del2_cx(genomic_del2_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del2_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -556,7 +556,7 @@ def genomic_del3_cx(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -581,7 +581,7 @@ def genomic_del3_free_text_cx(genomic_del3_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_free_text_subject,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -603,7 +603,7 @@ def genomic_del4_cx(genomic_del4_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -639,7 +639,7 @@ def genomic_del4_free_text_cx(genomic_del4_free_text_subject):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_free_text_subject,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -668,7 +668,7 @@ def genomic_uncertain_del_2():
             "end": [110207160, None],
             "type": "SequenceLocation",
         },
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -687,7 +687,7 @@ def genomic_uncertain_del_y():
             "end": [57165209, None],
             "type": "SequenceLocation",
         },
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
         "type": "CopyNumberChange",
     }
     return models.CopyNumberChange(**params)
@@ -710,7 +710,7 @@ def genomic_del5_cx_var(genomic_del5_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del5_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -721,7 +721,7 @@ def genomic_del6_cx_var(genomic_del6_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del6_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -778,7 +778,7 @@ async def test_genomic_dup1(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030072,
+        copy_change=models.CopyChange.HIGH_LEVEL_GAIN,
     )
     cnv_assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True, mane_genes_exts=True)
 
@@ -799,7 +799,7 @@ async def test_genomic_dup1(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030072,
+        copy_change=models.CopyChange.HIGH_LEVEL_GAIN,
     )
     cnv_assertion_checks(resp, genomic_dup1_cx, check_vrs_id=True, mane_genes_exts=True)
 
@@ -923,7 +923,7 @@ async def test_genomic_dup3(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030070,
+        copy_change=models.CopyChange.GAIN,
     )
     cnv_assertion_checks(resp, genomic_dup3_cx)
 
@@ -1181,7 +1181,7 @@ async def test_genomic_del1(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030064,
+        copy_change=models.CopyChange.REGIONAL_BASE_PLOIDY,
     )
     cnv_assertion_checks(resp, genomic_del1_cx, mane_genes_exts=True)
 
@@ -1200,7 +1200,7 @@ async def test_genomic_del1(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030064,
+        copy_change=models.CopyChange.REGIONAL_BASE_PLOIDY,
     )
     cnv_assertion_checks(resp, genomic_del1_cx, mane_genes_exts=True)
 
@@ -1253,7 +1253,7 @@ async def test_genomic_del2(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030069,
+        copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
     )
     cnv_assertion_checks(resp, genomic_del2_cx, mane_genes_exts=True)
 
@@ -1272,7 +1272,7 @@ async def test_genomic_del2(
     resp = await test_handler.normalize(
         q,
         HGVSDupDelModeOption.COPY_NUMBER_CHANGE,
-        copy_change=models.CopyChange.EFO_0030069,
+        copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
     )
     cnv_assertion_checks(resp, genomic_del2_cx, mane_genes_exts=True)
 

--- a/tests/to_copy_number_variation/test_amplification_to_cx_var.py
+++ b/tests/to_copy_number_variation/test_amplification_to_cx_var.py
@@ -11,7 +11,7 @@ def kit_amplification():
     params = {
         "type": "CopyNumberChange",
         "id": "ga4gh:CX.8ENbdAlnf3hK6681-74YhcnfD-J6WQbN",
-        "copyChange": {"primaryCode": "EFO:0030072"},
+        "copyChange": "high-level gain",
         "location": {
             "type": "SequenceLocation",
             "id": "ga4gh:SL.2xCHxtZBqOXxl4W4ACxq9Um4FqcqZKxL",

--- a/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_hgvs_to_copy_number.py
@@ -8,13 +8,13 @@ from tests.conftest import cnv_assertion_checks
 @pytest.fixture(scope="module")
 def genomic_dup1_cx_38(genomic_dup1_seq_loc_not_normalized):
     """Create test fixture copy number change variation"""
-    digest = "30bDl5yhHzjc4M5uGS_8IeYMzHQksQGh"
+    digest = "-PXHqkvTzdzEdLKzZ3Co7YysLSYuFShj"
     params = {
         "type": "CopyNumberChange",
         "id": f"ga4gh:CX.{digest}",
         "digest": digest,
         "location": genomic_dup1_seq_loc_not_normalized,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -51,7 +51,7 @@ def genomic_dup1_cx_37(genomic_dup1_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup1_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -62,7 +62,7 @@ def genomic_dup2_cx_38(genomic_dup2_seq_loc_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup2_seq_loc_normalized,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -99,7 +99,7 @@ def genomic_dup2_cx_37(genomic_dup2_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup2_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -110,7 +110,7 @@ def genomic_dup3_cx_38(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": {"primaryCode": "EFO:0030072"},
+        "copyChange": "high-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -146,7 +146,7 @@ def genomic_dup3_cx_37(genomic_dup3_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup3_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030072"},
+        "copyChange": "high-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -168,7 +168,7 @@ def genomic_dup4_cx_38(genomic_dup4_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_loc,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -204,7 +204,7 @@ def genomic_dup4_cx_37(genomic_dup4_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup4_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -226,7 +226,7 @@ def genomic_dup5_cx_38(genomic_dup5_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup5_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -262,7 +262,7 @@ def genomic_dup5_cx_37(genomic_dup5_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup5_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -284,7 +284,7 @@ def genomic_dup6_cx_38(genomic_dup6_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup6_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -320,7 +320,7 @@ def genomic_dup6_cx_37(genomic_dup6_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_dup6_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -331,7 +331,7 @@ def genomic_del1_cx_38(genomic_del1_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del1_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -368,7 +368,7 @@ def genomic_del1_cx_37(genomic_del1_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del1_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -379,7 +379,7 @@ def genomic_del2_cx_38(genomic_del2_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del2_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030071"},
+        "copyChange": "low-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -416,7 +416,7 @@ def genomic_del2_cx_37(genomic_del2_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del2_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030071"},
+        "copyChange": "low-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -427,7 +427,7 @@ def genomic_del3_cx_38(genomic_del3_dup3_loc_not_normalized):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_dup3_loc_not_normalized,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -452,7 +452,7 @@ def genomic_del3_cx_37(genomic_del3_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del3_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -474,7 +474,7 @@ def genomic_del4_cx_38(genomic_del4_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -510,7 +510,7 @@ def genomic_del4_cx_37(genomic_del4_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del4_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030067"},
+        "copyChange": "loss",
     }
     return models.CopyNumberChange(**params)
 
@@ -532,7 +532,7 @@ def genomic_del5_cx_38(genomic_del5_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del5_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -568,7 +568,7 @@ def genomic_del5_cx_37(genomic_del5_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del5_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030064"},
+        "copyChange": "regional base ploidy",
     }
     return models.CopyNumberChange(**params)
 
@@ -590,7 +590,7 @@ def genomic_del6_cx_38(genomic_del6_seq_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del6_seq_loc,
-        "copyChange": {"primaryCode": "EFO:0030071"},
+        "copyChange": "low-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -626,7 +626,7 @@ def genomic_del6_cx_37(genomic_del6_37_loc):
     params = {
         "type": "CopyNumberChange",
         "location": genomic_del6_37_loc,
-        "copyChange": {"primaryCode": "EFO:0030071"},
+        "copyChange": "low-level gain",
     }
     return models.CopyNumberChange(**params)
 
@@ -663,18 +663,18 @@ async def test_genomic_dup1_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000003.12:g.49531262dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=False
+        q, copy_change="complete genomic loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup1_cx_38, check_vrs_id=True)
 
     q = "NC_000003.11:g.49568695dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=False
+        q, copy_change="complete genomic loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup1_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=True
+        q, copy_change="complete genomic loss", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup1_cx_38)
 
@@ -709,18 +709,18 @@ async def test_genomic_dup2_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.33211290_33211293dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=False
+        q, copy_change="loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup2_cx_38)
 
     q = "NC_000023.10:g.33229407_33229410dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=False
+        q, copy_change="loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup2_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=True
+        q, copy_change="loss", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup2_cx_38)
 
@@ -755,18 +755,18 @@ async def test_genomic_dup3_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030072", do_liftover=False
+        q, copy_change="high-level gain", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup3_cx_38)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030072", do_liftover=False
+        q, copy_change="high-level gain", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup3_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030072", do_liftover=True
+        q, copy_change="high-level gain", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup3_cx_38)
 
@@ -801,18 +801,18 @@ async def test_genomic_dup4_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000020.11:g.(?_30417576)_(31394018_?)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=False
+        q, copy_change="complete genomic loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup4_cx_38)
 
     q = "NC_000020.10:g.(?_29652252)_(29981821_?)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=False
+        q, copy_change="complete genomic loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup4_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=True
+        q, copy_change="complete genomic loss", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup4_cx_38)
 
@@ -847,18 +847,18 @@ async def test_genomic_dup5_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.(?_154021812)_154092209dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=False
+        q, copy_change="loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup5_cx_38)
 
     q = "NC_000023.10:g.(?_153287263)_153357667dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=False
+        q, copy_change="loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup5_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=True
+        q, copy_change="loss", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup5_cx_38)
 
@@ -893,18 +893,18 @@ async def test_genomic_dup6_copy_number_change(
     """Test that genomic duplication works correctly"""
     q = "NC_000023.11:g.154021812_(154092209_?)dup"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=False
+        q, copy_change="regional base ploidy", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup6_cx_38)
 
     q = "NC_000023.10:g.153287263_(153357667_?)dup"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=False
+        q, copy_change="regional base ploidy", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_dup6_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=True
+        q, copy_change="regional base ploidy", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_dup6_cx_38)
 
@@ -939,18 +939,18 @@ async def test_genomic_del1_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10149811del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=False
+        q, copy_change="regional base ploidy", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del1_cx_38)
 
     q = "NC_000003.11:g.10191495del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=False
+        q, copy_change="regional base ploidy", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del1_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=True
+        q, copy_change="regional base ploidy", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del1_cx_38)
 
@@ -985,18 +985,18 @@ async def test_genomic_del2_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000003.12:g.10146595_10146613del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=False
+        q, copy_change="low-level gain", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del2_cx_38)
 
     q = "NC_000003.11:g.10188279_10188297del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=False
+        q, copy_change="low-level gain", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del2_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=True
+        q, copy_change="low-level gain", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del2_cx_38)
 
@@ -1031,18 +1031,18 @@ async def test_genomic_del3_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=False
+        q, copy_change="complete genomic loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del3_cx_38)
 
     q = "NC_000023.10:g.(31078344_31118468)_(33292395_33435268)del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=False
+        q, copy_change="complete genomic loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del3_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030069", do_liftover=True
+        q, copy_change="complete genomic loss", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del3_cx_38)
 
@@ -1077,18 +1077,18 @@ async def test_genomic_del4_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_31120496)_(33339477_?)del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=False
+        q, copy_change="loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del4_cx_38)
 
     q = "NC_000023.10:g.(?_31138613)_(33357594_?)del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=False
+        q, copy_change="loss", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del4_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030067", do_liftover=True
+        q, copy_change="loss", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del4_cx_38)
 
@@ -1123,18 +1123,18 @@ async def test_genomic_del5_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000023.11:g.(?_18575354)_18653629del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=False
+        q, copy_change="regional base ploidy", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del5_cx_38)
 
     q = "NC_000023.10:g.(?_18593474)_18671749del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=False
+        q, copy_change="regional base ploidy", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del5_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030064", do_liftover=True
+        q, copy_change="regional base ploidy", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del5_cx_38)
 
@@ -1169,18 +1169,18 @@ async def test_genomic_del6_copy_number_change(
     """Test that genomic deletion works correctly"""
     q = "NC_000006.12:g.133462764_(133464858_?)del"  # 38
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=False
+        q, copy_change="low-level gain", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del6_cx_38)
 
     q = "NC_000006.11:g.133783902_(133785996_?)del"  # 37
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=False
+        q, copy_change="low-level gain", do_liftover=False
     )
     cnv_assertion_checks(resp, genomic_del6_cx_37)
 
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=True
+        q, copy_change="low-level gain", do_liftover=True
     )
     cnv_assertion_checks(resp, genomic_del6_cx_38)
 
@@ -1191,7 +1191,7 @@ async def test_invalid_cnv(test_cnv_handler):
     q = "DAG1 g.49568695dup"
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
         q,
-        copy_change="EFO:0030071",
+        copy_change="low-level gain",
         do_liftover=True,
     )
     assert set(resp.warnings) == {
@@ -1201,7 +1201,7 @@ async def test_invalid_cnv(test_cnv_handler):
 
     q = "braf V600E"
     resp = await test_cnv_handler.hgvs_to_copy_number_change(
-        q, copy_change="EFO:0030071", do_liftover=True
+        q, copy_change="low-level gain", do_liftover=True
     )
     assert set(resp.warnings) == {
         "braf V600E is not a supported HGVS genomic duplication or deletion"

--- a/tests/to_copy_number_variation/test_parsed_to_copy_number.py
+++ b/tests/to_copy_number_variation/test_parsed_to_copy_number.py
@@ -152,7 +152,7 @@ def cn_definite_number():
 @pytest.fixture(scope="module")
 def cx_numbers():
     """Create test fixture for copy number change using numbers for start and end"""
-    cx_digest = "XIsVHbhEUbXraIgpgV4ToCa-6oZWMRUD"
+    cx_digest = "AikSAwyBq4t71coigYRGxcsvuWyAUU-8"
     loc_digest = "Iz_azSFTEulx7tCluLgGhE1n0hTLUocb"
     variation = {
         "type": "CopyNumberChange",
@@ -169,7 +169,7 @@ def cx_numbers():
             "start": 10000,
             "end": 1223133,
         },
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**variation)
 
@@ -190,7 +190,7 @@ def cx_definite_ranges():
             "start": [10000, 10005],
             "end": [1223130, 1223133],
         },
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**variation)
 
@@ -211,7 +211,7 @@ def cx_indefinite_ranges():
             "start": [None, 10000],
             "end": [1223130, None],
         },
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**variation)
 
@@ -232,7 +232,7 @@ def cx_number_indefinite():
             "start": 10000,
             "end": [1223130, None],
         },
-        "copyChange": {"primaryCode": "EFO:0030069"},
+        "copyChange": "complete genomic loss",
     }
     return models.CopyNumberChange(**variation)
 
@@ -795,7 +795,7 @@ def test_parsed_to_cx_var(
     rb = ParsedToCxVarQuery(
         start0=10001,
         end0=1223133,
-        copy_change=models.CopyChange.EFO_0030069,
+        copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
         assembly=ClinVarAssembly.GRCH38,
         chromosome="chrY",
         start_pos_type=ParsedPosType.NUMBER,
@@ -808,7 +808,7 @@ def test_parsed_to_cx_var(
     rb = ParsedToCxVarQuery(
         start0=10001,
         end0=1223130,
-        copy_change=models.CopyChange.EFO_0030069,
+        copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
         assembly=ClinVarAssembly.GRCH38,
         chromosome="chrY",
         start_pos_type=ParsedPosType.DEFINITE_RANGE,
@@ -823,7 +823,7 @@ def test_parsed_to_cx_var(
     rb = ParsedToCxVarQuery(
         start0=10001,
         end0=1223130,
-        copy_change=models.CopyChange.EFO_0030069,
+        copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
         assembly=ClinVarAssembly.GRCH38,
         chromosome="chrY",
         start_pos_type=ParsedPosType.INDEFINITE_RANGE,
@@ -838,7 +838,7 @@ def test_parsed_to_cx_var(
     rb = ParsedToCxVarQuery(
         start0=10001,
         end0=1223130,
-        copy_change=models.CopyChange.EFO_0030069,
+        copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
         assembly=ClinVarAssembly.GRCH38,
         chromosome="chrY",
         start_pos_type=ParsedPosType.NUMBER,
@@ -856,16 +856,16 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=10491132,
             end0=10535643,
-            copy_change="efo:1234",
+            copy_change="EFO:0030071",
             accession="NC_000001.10",
         )
-    assert "Input should be 'EFO:" in str(e.value)
+    assert "Input should be 'complete genomic loss', 'high-level loss'," in str(e.value)
 
     # NCBI36/hg18 assembly
     rb = ParsedToCxVarQuery(
         start0=2623228,
         end0=3150942,
-        copy_change=models.CopyChange.EFO_0030070,
+        copy_change=models.CopyChange.GAIN,
         assembly=ClinVarAssembly.NCBI36,
         chromosome="chr1",
     )
@@ -876,7 +876,7 @@ def test_invalid(test_cnv_handler):
     rb = ParsedToCxVarQuery(
         start0=2623228,
         end0=3150942,
-        copy_change=models.CopyChange.EFO_0030070,
+        copy_change=models.CopyChange.GAIN,
         assembly=ClinVarAssembly.HG18,
         chromosome="chr1",
     )
@@ -892,7 +892,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=31738809,
             end0=32217725,
-            copy_change=models.CopyChange.EFO_0030070,
+            copy_change=models.CopyChange.GAIN,
             assembly="hg38",
         )
     assert ac_assembly_chr_msg in str(e.value)
@@ -902,7 +902,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=31738809,
             end0=32217725,
-            copy_change=models.CopyChange.EFO_0030070,
+            copy_change=models.CopyChange.GAIN,
             chromosome="chr15",
         )
     assert ac_assembly_chr_msg in str(e.value)
@@ -912,7 +912,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=31738809,
             end0=32217725,
-            copy_change=models.CopyChange.EFO_0030070,
+            copy_change=models.CopyChange.GAIN,
         )
     assert ac_assembly_chr_msg in str(e.value)
 
@@ -921,7 +921,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=10001,
             end0=1223133,
-            copy_change=models.CopyChange.EFO_0030070,
+            copy_change=models.CopyChange.GAIN,
             assembly=ClinVarAssembly.GRCH38,
             chromosome="z",
         )
@@ -934,7 +934,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=10001,
             end0=1223133,
-            copy_change=models.CopyChange.EFO_0030070,
+            copy_change=models.CopyChange.GAIN,
             assembly="GRCh99",
         )
     assert "Input should be 'GRCh38'," in str(e.value)
@@ -943,7 +943,7 @@ def test_invalid(test_cnv_handler):
     rb = ParsedToCxVarQuery(
         start0=10491132,
         end0=10535643,
-        copy_change=models.CopyChange.EFO_0030070,
+        copy_change=models.CopyChange.GAIN,
         accession="NC_00002310",
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -956,7 +956,7 @@ def test_invalid(test_cnv_handler):
     rb = ParsedToCxVarQuery(
         start0=31738809,
         end0=2302991250,
-        copy_change=models.CopyChange.EFO_0030070,
+        copy_change=models.CopyChange.GAIN,
         accession="NC_000015.10",
     )
     resp = test_cnv_handler.parsed_to_copy_number(rb)
@@ -968,7 +968,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=10001,
             end0=1223130,
-            copy_change=models.CopyChange.EFO_0030069,
+            copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
             assembly=ClinVarAssembly.GRCH38,
             chromosome="chrY",
             start_pos_type=ParsedPosType.DEFINITE_RANGE,
@@ -983,7 +983,7 @@ def test_invalid(test_cnv_handler):
         ParsedToCxVarQuery(
             start0=10001,
             end0=1223130,
-            copy_change=models.CopyChange.EFO_0030069,
+            copy_change=models.CopyChange.COMPLETE_GENOMIC_LOSS,
             assembly=ClinVarAssembly.GRCH38,
             chromosome="chrY",
             start_pos_type=ParsedPosType.DEFINITE_RANGE,


### PR DESCRIPTION
close #607

* Update ga4gh.vrs + gene normalizer versions to leverage vrs 2.0.1 models

@Mrinal-Thomas-Epic @kattaylor511 This is the update we need to get VRS 2.0.1 IDs