### PR TITLE
feat: Address deletion and substitution bugs in `gnomad_vcf_to_protein_variation.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "ga4gh.vrs[extras] >=2.2.0,<3.0",
     "gene-normalizer >=0.9.0",
     "boto3",
-    "cool-seq-tool ~=0.15.2",
+    "cool-seq-tool ~=0.15.3",
     "bioutils"
 ]
 

--- a/src/variation/gnomad_vcf_to_protein_variation.py
+++ b/src/variation/gnomad_vcf_to_protein_variation.py
@@ -561,10 +561,25 @@ class GnomadVcfToProteinVariation:
             ref = ref[::-1]
 
         # Get genomic altered sequence
+        # For deletions that occur in the first reading frame, the retained,
+        # altered sequence would include the original string provided in the
+        # alt section of the VCF expression + the dna sequence that is retained
+        # within the computed genomic position range
         if alt_type == AltType.DELETION and genomic_start_ix == 0:
-            retained_dna = self.seqrepo_access.get_reference_sequence(
+            retained_dna, w = self.seqrepo_access.get_reference_sequence(
                 g_ac, new_g_start_pos + len_g_ref, new_g_end_pos
-            )[0]
+            )
+            if w:
+                warnings.append(w)
+                return GnomadVcfToProteinService(
+                    variation_query=vcf_query,
+                    variation=variation,
+                    warnings=warnings,
+                    service_meta_=ServiceMeta(
+                        version=__version__,
+                        response_datetime=datetime.datetime.now(tz=datetime.UTC),
+                    ),
+                )
             alt = g_alt + retained_dna
         else:
             alt = self._get_genomic_alt(

--- a/src/variation/gnomad_vcf_to_protein_variation.py
+++ b/src/variation/gnomad_vcf_to_protein_variation.py
@@ -541,7 +541,6 @@ class GnomadVcfToProteinVariation:
         new_g_start_pos, new_g_end_pos, genomic_start_ix = self._get_genomic_pos_range(
             c_data.pos[0], c_data.pos[1], strand, g_start_pos, g_end_pos
         )
-
         # Get genomic reference sequence
         ref, w = self.seqrepo_access.get_reference_sequence(
             g_ac, new_g_start_pos, new_g_end_pos
@@ -562,9 +561,15 @@ class GnomadVcfToProteinVariation:
             ref = ref[::-1]
 
         # Get genomic altered sequence
-        alt = self._get_genomic_alt(
-            g_ac, g_alt, new_g_end_pos, alt_type, genomic_start_ix, strand, ref
-        )
+        if alt_type == AltType.DELETION and genomic_start_ix == 0:
+            retained_dna = self.seqrepo_access.get_reference_sequence(
+                g_ac, new_g_start_pos + len_g_ref, new_g_end_pos
+            )[0]
+            alt = g_alt + retained_dna
+        else:
+            alt = self._get_genomic_alt(
+                g_ac, g_alt, new_g_end_pos, alt_type, genomic_start_ix, strand, ref
+            )
 
         # DNA -> RNA -> Protein (1 AA)
         aa_ref = self._dna_to_aa(ref, strand)
@@ -577,8 +582,7 @@ class GnomadVcfToProteinVariation:
         )
         aa_ref, aa_alt, _ = _trim_prefix_or_suffix(aa_ref, aa_alt, trim_prefix=False)
 
-        # Get protein end position
-        if alt_type == AltType.DELETION:
+        if alt_type == AltType.DELETION and genomic_start_ix != 0:
             aa_end_pos = aa_start_pos + (len(aa_ref) - 1)
         else:
             aa_end_pos = p_data.pos[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,46 @@ def protein_insertion():
 
 
 @pytest.fixture(scope="session")
+def pik3r1_deletion():
+    "Create test fixture for PIK3R1 deletion"
+    params = {
+        "location": {
+            "end": 573,
+            "start": 570,
+            "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.jwl0YkGsFI99ObXiyutSbGP4K8D_yi5K",
+            },
+            "sequence": "IQL",
+            "type": "SequenceLocation",
+        },
+        "state": {"sequence": "M", "type": "LiteralSequenceExpression"},
+        "type": "Allele",
+    }
+    return models.Allele(**params)
+
+
+@pytest.fixture(scope="session")
+def cdkn2a_substitution():
+    "Create test fixture for CDKN2A deletion"
+    params = {
+        "location": {
+            "end": 58,
+            "start": 57,
+            "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.ezr7VxeJXsAWsbni4UYOKyGUTjD82dIY",
+            },
+            "sequence": "R",
+            "type": "SequenceLocation",
+        },
+        "state": {"sequence": "*", "type": "LiteralSequenceExpression"},
+        "type": "Allele",
+    }
+    return models.Allele(**params)
+
+
+@pytest.fixture(scope="session")
 def protein_deletion_np_range():
     """Create test fixture for protein deletion using NP accession and
     range for deletion.

--- a/tests/test_gnomad_vcf_to_protein.py
+++ b/tests/test_gnomad_vcf_to_protein.py
@@ -348,27 +348,33 @@ async def test_insertion(test_handler, protein_insertion, protein_insertion2):
 
 
 @pytest.mark.asyncio
-async def test_deletion(test_handler, pik3r1_deletion, cdkn2a_substitution, protein_deletion_np_range, cdk11a_e314del):
+async def test_deletion(
+    test_handler,
+    pik3r1_deletion,
+    cdkn2a_substitution,
+    protein_deletion_np_range,
+    cdk11a_e314del,
+):
     """Test that deletion queries return correct response"""
-    # Reading Frame 0, Positive Strand
+    # Reading Frame 0, Positive Strand (CA3250144726)
     resp = await test_handler.gnomad_vcf_to_protein("5-68295290-ATCCAGC-A")
     assertion_checks(resp, pik3r1_deletion)
     assert resp.gene_context
     assert resp.warnings == []
 
-    # Reading Frame 0, Negative Strand
+    # Reading Frame 0, Negative Strand (CA16602756)
     resp = await test_handler.gnomad_vcf_to_protein("9-21971187-G-A")
     assertion_checks(resp, cdkn2a_substitution)
     assert resp.gene_context
     assert resp.warnings == []
 
-    # Reading Frame 0, Positive Strand
+    # Reading Frame 0, Positive Strand (CA645372623)
     resp = await test_handler.gnomad_vcf_to_protein("17-39723966-TTGAGGGAAAACACAT-T")
     assertion_checks(resp, protein_deletion_np_range)
     assert resp.gene_context
     assert resp.warnings == []
 
-    # Reading Frame 2, Negative Strand
+    # Reading Frame 2, Negative Strand (CA521012075)
     resp = await test_handler.gnomad_vcf_to_protein("1-1708855-TTCC-T")
     assertion_checks(resp, cdk11a_e314del)
     assert resp.gene_context

--- a/tests/test_gnomad_vcf_to_protein.py
+++ b/tests/test_gnomad_vcf_to_protein.py
@@ -348,13 +348,27 @@ async def test_insertion(test_handler, protein_insertion, protein_insertion2):
 
 
 @pytest.mark.asyncio
-async def test_deletion(test_handler, protein_deletion_np_range, cdk11a_e314del):
+async def test_deletion(test_handler, pik3r1_deletion, cdkn2a_substitution, protein_deletion_np_range, cdk11a_e314del):
     """Test that deletion queries return correct response"""
+    # Reading Frame 0, Positive Strand
+    resp = await test_handler.gnomad_vcf_to_protein("5-68295290-ATCCAGC-A")
+    assertion_checks(resp, pik3r1_deletion)
+    assert resp.gene_context
+    assert resp.warnings == []
+
+    # Reading Frame 0, Negative Strand
+    resp = await test_handler.gnomad_vcf_to_protein("9-21971187-G-A")
+    assertion_checks(resp, cdkn2a_substitution)
+    assert resp.gene_context
+    assert resp.warnings == []
+
+    # Reading Frame 0, Positive Strand
     resp = await test_handler.gnomad_vcf_to_protein("17-39723966-TTGAGGGAAAACACAT-T")
     assertion_checks(resp, protein_deletion_np_range)
     assert resp.gene_context
     assert resp.warnings == []
 
+    # Reading Frame 2, Negative Strand
     resp = await test_handler.gnomad_vcf_to_protein("1-1708855-TTCC-T")
     assertion_checks(resp, cdk11a_e314del)
     assert resp.gene_context


### PR DESCRIPTION
closes #447 

Not entirely sure why my reading frame change works, but would like to test with other known cases if possible