### PR TITLE
chore: bump version from 0.15.2 to 0.15.3

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: cancervariants/variation-normalizer-api:0.15.2
+    image: cancervariants/variation-normalizer-api:0.15.3
     environment:
       SEQREPO_ROOT_DIR: /usr/local/share/seqrepo/2024-12-20
       # Dummy AWS credentials, don't need to use real ones

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "variation-normalizer"
-version = "0.15.2"
+version = "0.15.3"
 authors = [
     {name = "Alex Wagner"},
     {name = "Kori Kuzma"},


### PR DESCRIPTION
* Prep for patch release

Hoping to also include #653 & #654 in this 0.15.3 release. Docker image has **not** been published yet, will do this after the release is made.