### PR TITLE
build: update coolseqtool dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "ga4gh.vrs[extras] >=2.3.0,<3.0",
     "gene-normalizer >=0.9.0",
     "boto3",
-    "cool-seq-tool ~=0.15.4",
+    "cool-seq-tool ~=0.16.0",
     "bioutils"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ charset-normalizer==3.4.4
 click==8.3.0
 coloredlogs==15.0.1
 configparser==7.2.0
-cool-seq-tool==0.15.4
+cool-seq-tool==0.16.0
 decorator==5.2.1
 dill==0.3.9
 executing==2.2.1


### PR DESCRIPTION
bump CST dependency

* tests pass locally for me
* any other version pins to change?
* I ctrl-f'd for any cases of "tx_exon_aln" since those method names were changed, but I didn't find any